### PR TITLE
parser: implement a simple FOL parser

### DIFF
--- a/MacadamiaSolver.opam
+++ b/MacadamiaSolver.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/MacadamiaSolver/MacadamiaSolver/issues"
 depends: [
   "ocaml"
   "dune" {>= "3.16"}
+  "angstrom" {>= "0.16.0"}
   "alcotest" {with-test}
   "ocamlformat" {= "0.26.2" & dev}
   "odoc" {with-doc}

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,4 +4,10 @@
 
 open Lib
 
-let () = print_endline (HelloWorld.getString ())
+let () =
+  let rec input_and_solve () =
+    let expr = read_line () in
+    let ast = Parser.parse expr in
+    input_and_solve (print_endline (Ast.string_of_formula ast))
+  in
+  input_and_solve ()

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,7 @@
  (depends 
    ocaml 
    dune 
+   angstrom 
    (alcotest :with-test)
    (ocamlformat
     (and

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -1,0 +1,60 @@
+(** Copyright 2024, MacadamiaSolver. *)
+
+(** SPDX-License-Identifier: MIT *)
+
+type varname = string
+
+type term = Var of varname | Const of int | Add of term * term
+
+type formula =
+  | Equals of term * term
+  | Mnot of formula
+  | Mand of formula * formula
+  | Mor of formula * formula
+  | Mimpl of formula * formula
+  | Exists of varname * formula
+  | Any of varname * formula
+
+let var x = Var x
+
+let const x = Const x
+
+let add x y = Add (x, y)
+
+let equals x y = Equals (x, y)
+
+let mnot x = Mnot x
+
+let mand x y = Mand (x, y)
+
+let mor x y = Mor (x, y)
+
+let mimpl x y = Mimpl (x, y)
+
+let exists x y = Exists (x, y)
+
+let any x y = Any (x, y)
+
+let rec string_of_term = function
+  | Var n ->
+      "(Var " ^ n ^ ")"
+  | Const n ->
+      "(Const " ^ string_of_int n ^ ")"
+  | Add (a, b) ->
+      "(Add " ^ string_of_term a ^ " " ^ string_of_term b ^ ")"
+
+let rec string_of_formula = function
+  | Equals (a, b) ->
+      "(Equals " ^ string_of_term a ^ " " ^ string_of_term b ^ ")"
+  | Mnot a ->
+      "(Not " ^ string_of_formula a ^ ")"
+  | Mand (a, b) ->
+      "(And " ^ string_of_formula a ^ " " ^ string_of_formula b ^ ")"
+  | Mor (a, b) ->
+      "(Or " ^ string_of_formula a ^ " " ^ string_of_formula b ^ ")"
+  | Mimpl (a, b) ->
+      "(Impl " ^ string_of_formula a ^ " " ^ string_of_formula b ^ ")"
+  | Exists (x, a) ->
+      "(Exists " ^ x ^ " " ^ string_of_formula a ^ ")"
+  | Any (x, a) ->
+      "(Any " ^ x ^ " " ^ string_of_formula a ^ ")"

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -1,0 +1,40 @@
+(** Copyright 2024, MacadamiaSolver. *)
+
+(** SPDX-License-Identifier: MIT *)
+
+type varname = string
+
+type term = Var of varname | Const of int | Add of term * term
+
+type formula =
+  | Equals of term * term
+  | Mnot of formula
+  | Mand of formula * formula
+  | Mor of formula * formula
+  | Mimpl of formula * formula
+  | Exists of varname * formula
+  | Any of varname * formula
+
+val var : varname -> term
+
+val const : int -> term
+
+val add : term -> term -> term
+
+val equals : term -> term -> formula
+
+val mnot : formula -> formula
+
+val mand : formula -> formula -> formula
+
+val mor : formula -> formula -> formula
+
+val mimpl : formula -> formula -> formula
+
+val exists : varname -> formula -> formula
+
+val any : varname -> formula -> formula
+
+val string_of_term : term -> string
+
+val string_of_formula : formula -> string

--- a/lib/dune
+++ b/lib/dune
@@ -1,2 +1,4 @@
 (library
- (name lib))
+ (name lib)
+ (modules Ast Parser)
+ (libraries base angstrom))

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -1,0 +1,75 @@
+(** Copyright 2024, MacadamiaSolver. *)
+
+(** SPDX-License-Identifier: MIT *)
+
+open Angstrom
+
+let ( << ) f g x = f (g x)
+
+let is_whitespace = function ' ' | '\t' | '\n' | '\r' -> true | _ -> false
+
+let whitespace = take_while is_whitespace
+
+let is_digit = function '0' .. '9' -> true | _ -> false
+
+let integer = take_while1 is_digit >>| (Ast.const << int_of_string)
+
+let is_smallchar = function 'a' .. 'z' -> true | _ -> false
+
+let varname =
+  lift2
+    (fun a b -> String.make 1 a ^ b)
+    (satisfy is_smallchar) (take_while is_digit)
+
+let var = varname >>| Ast.var
+
+let sum = whitespace *> char '+' *> whitespace *> return Ast.add
+
+let parens p = char '(' *> whitespace *> p <* whitespace <* char ')'
+
+let chainl1 e op =
+  let rec go acc = lift2 (fun f x -> f acc x) op e >>= go <|> return acc in
+  e >>= go
+
+let term =
+  fix (fun _ ->
+      let aterm = integer <|> var in
+      chainl1 aterm sum )
+
+let mand = whitespace *> char '&' *> whitespace *> return Ast.mand
+
+let mor = whitespace *> char '|' *> whitespace *> return Ast.mor
+
+let mimpl = whitespace *> string "->" *> whitespace *> return Ast.mimpl
+
+let equals = whitespace *> char '=' *> whitespace *> return Ast.equals
+
+let formula =
+  fix (fun formula ->
+      let equals =
+        lift3
+          (fun a _ b -> Ast.equals a b)
+          term
+          (whitespace *> char '=' *> whitespace)
+          term
+      in
+      let mnot = char '~' *> whitespace *> formula >>| Ast.mnot in
+      let exists =
+        char 'E'
+        *> lift2 (fun a b -> Ast.exists a b) varname (whitespace *> formula)
+      in
+      let any =
+        char 'A'
+        *> lift2 (fun a b -> Ast.any a b) varname (whitespace *> formula)
+      in
+      let aformula = parens formula <|> exists <|> any <|> mnot <|> equals in
+      let aformula2 = chainl1 aformula mand in
+      let aformula3 = chainl1 aformula2 mor in
+      chainl1 aformula3 mimpl )
+
+let parse (str : string) : Ast.formula =
+  match parse_string ~consume:All formula str with
+    | Ok v ->
+        v
+    | Error msg ->
+        failwith msg

--- a/test/unit/TestHelloWorld.ml
+++ b/test/unit/TestHelloWorld.ml
@@ -1,7 +1,0 @@
-open Lib
-
-module TestHelloWorld = struct
-  let test () =
-    Alcotest.(check string)
-      "same string" "Hello world" (HelloWorld.getString ())
-end

--- a/test/unit/TestParser.ml
+++ b/test/unit/TestParser.ml
@@ -1,0 +1,38 @@
+open Lib
+
+let test_exists_bigger () =
+  Alcotest.(check string)
+    "same string" "(Any x (Exists y (Equals (Var x) (Add (Var y) (Const 1)))))"
+    (Ast.string_of_formula (Parser.parse "AxEy x = y + 1"))
+
+let test_no_biggest_int () =
+  Alcotest.(check string)
+    "same string"
+    "(Not (Exists x (Any y (Exists z (Equals (Var x) (Add (Var y) (Var z)))))))"
+    (Ast.string_of_formula (Parser.parse "~ExAyEz(x = y + z)"))
+
+let test_divisible_by_7 () =
+  Alcotest.(check string)
+    "same string"
+    "(Exists x (Equals (Var y) (Add (Add (Add (Add (Add (Add (Var x) (Var x)) \
+     (Var x)) (Var x)) (Var x)) (Var x)) (Var x))))"
+    (Ast.string_of_formula (Parser.parse "Ex y = x + x + x + x + x + x + x"))
+
+let test_sum_of_evens_is_even () =
+  Alcotest.(check string)
+    "same string"
+    "(Any x (Any y (Impl (And (Exists z (Equals (Var x) (Add (Var z) (Var \
+     z)))) (Exists w (Equals (Var y) (Add (Var w) (Var w))))) (Exists v \
+     (Equals (Add (Var x) (Var y)) (Add (Var v) (Var v)))))))"
+    (Ast.string_of_formula
+       (Parser.parse
+          "AxAy((Ez x = z + z) & (Ew y = w + w) -> (Ev x + y = v + v))" ) )
+
+let tests =
+  ( "Parser"
+  , [ Alcotest.test_case "Exists bigger int for any int" `Quick
+        test_exists_bigger
+    ; Alcotest.test_case "No biggest int exists" `Quick test_no_biggest_int
+    ; Alcotest.test_case "Divisible by 7 integers" `Quick test_divisible_by_7
+    ; Alcotest.test_case "Sum of evens is even" `Quick test_sum_of_evens_is_even
+    ] )

--- a/test/unit/Unit.ml
+++ b/test/unit/Unit.ml
@@ -1,6 +1,1 @@
-open TestHelloWorld
-
-let () =
-  let open Alcotest in
-  run "HelloWorld"
-    [("getString", [test_case "Simple" `Quick TestHelloWorld.test])]
+let () = Alcotest.run "MacadamiaSolver" [TestParser.tests]


### PR DESCRIPTION
This patch adds a simple first-order logic over the signature <0, 1, +, => expression parser.

The supported syntax is:
- `[a-z]\d*` - for specifying variables.
- `\d+` - for specifying constants.
- `+` - for the sum.
- `=` - for the equality predicate.
- `~ & | ->` - and/or/implication/not logical connectives.
- `E/A` - exists/any quantifiers.

Notes:
- For versatility the constants are supported in order not to write a lot of `1 + 1 + ... + 1` symbols.
- The solver is going to work with the PrA (Presburger arithmetic) expressions so the multiplication is obsolete.

The quantifiers have the lowest priority. The logical connectives use the most common priority ordering (`not -> and -> or -> implication`).

The spaces are mostly ignored. The only exception the variable name should be placed exactly right after the quantifier (`Ex<formula>` or `Ay<formula>`.

A few examples of the theorems:
```
There is an even integer:
ExEy x = y + y

x = y iff x = y + 0:
AxAy (x = y + 0 -> x = y) & (x = y -> x = y + 0)
```

The AST tree of the formula can be converted into a string using the `string_of_formula` function.

Closes #3