### PR TITLE
ci: get rid of zanuda linter

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Build
         run: opam exec -- dune build @check @all
 
-      - name: Lint
-        run: opam exec -- zanuda -dir . | tee result; if [[ -z $(cat result) ]]; then exit 0; else exit 1; fi
-
       - name: Tests
         run: opam exec -- dune runtest
 

--- a/MacadamiaSolver.opam
+++ b/MacadamiaSolver.opam
@@ -11,7 +11,6 @@ depends: [
   "ocaml"
   "dune" {>= "3.16"}
   "alcotest" {with-test}
-  "zanuda"
   "ocamlformat" {= "0.26.2" & dev}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,6 @@
    ocaml 
    dune 
    (alcotest :with-test)
-   zanuda
    (ocamlformat
     (and
      (= 0.26.2)


### PR DESCRIPTION
This patch removes the zanuda linter from the CI because of the too strict restrictions on the writting code applyable mostly to enterprise projects rather than simple research ones.

A few examples of such nasty lints:
- The code should contain documentation.
- The license text should be supplied everywhere.
- The method X is slower than Y. So use Y (even for debug purposes).

Following these guidelines is quite tough for the project. And the OCaml compiler is pretty good at pointing out a few lints (like unused variables) itself.