### PR TITLE
solver: add support for PrA solution procedure

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,14 +4,53 @@
 
 open Lib
 
+let exec line = function
+  | Ast.Eval f -> (
+      let res = Solver.proof f in
+      match res with
+        | Ok res ->
+            Format.printf "Result: %b\n\n%!" res
+        | Error msg ->
+            Format.printf "Error: %s\n\n%!" msg )
+  | Ast.Dump f -> (
+    match Solver.dump f with
+      | Ok s ->
+          let dot_file = Format.sprintf "dumps/\"%s.dot\"" line in
+          let svg_file = Format.sprintf "dumps/\"%s.svg\"" line in
+          let oc = open_out (Format.sprintf "dumps/%s.dot" line) in
+          let command =
+            Format.sprintf "mkdir -p dumps/; dot -Tsvg %s > %s; xdg-open %s"
+              dot_file svg_file svg_file
+          in
+          Printf.fprintf oc "%s" s;
+          close_out oc;
+          Sys.command command |> ignore
+      | Error msg ->
+          Format.printf "Error: %s\n\n%!" msg )
+  | Ast.Def (name, params, formula) -> (
+    match Solver.pred name params formula with
+      | Ok () ->
+          ()
+      | Error msg ->
+          Format.printf "Error: %s\n\n%!" msg )
+  | Ast.Parse f ->
+      Format.printf "Formula AST: %a\n%!" Ast.pp_formula f
+  (* TODO: Support for optimizer. *)
+  (* Format.printf "Optimized AST: %a\n\n%!" Ast.pp_formula f *)
+  | Ast.List ->
+      Solver.list ()
+  | Ast.Help ->
+      ()
+
 let () =
-  let rec input_and_solve () =
-    let expr = read_line () in
-    let ast = Parser.parse_formula expr in
-    match ast with
-      | Ok f ->
-          input_and_solve (Format.printf "%a" Ast.pp_formula f)
-      | Error err ->
-          input_and_solve (Format.printf "Error: %s" err)
+  let rec aux () =
+    let line = read_line () in
+    let stmt = Parser.parse line in
+    match stmt with
+      | Ok stmt ->
+          exec line stmt; aux ()
+      | Error msg ->
+          Format.printf "Error: %s\n\n%!" msg;
+          aux ()
   in
-  input_and_solve ()
+  aux ()

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -170,6 +170,17 @@ let binconj_ast_exn = function
   | _ ->
       assert false
 
+let tfold ft acc t =
+  let rec foldt acc = function
+    | (Const _ | Var _) as f ->
+        ft acc f
+    | (Pow (_, t1) | Mul (_, t1)) as t ->
+        ft (foldt acc t1) t
+    | Add (t1, t2) as t ->
+        ft (foldt (foldt acc t1) t2) t
+  in
+  foldt acc t
+
 let fold ff ft acc f =
   let rec foldt acc = function
     | (Const _ | Var _) as f ->

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -102,6 +102,8 @@ val quantifier_ast_exn : formula -> varname list -> formula -> formula
 
 val binconj_ast_exn : formula -> formula -> formula -> formula
 
+val tfold : ('acc -> term -> 'acc) -> 'acc -> term -> 'acc
+
 val fold :
   ('acc -> formula -> 'acc) -> ('acc -> term -> 'acc) -> 'acc -> formula -> 'acc
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name lib)
- (modules Ast Parser Nfa NfaCollection Utils)
+ (modules Ast Parser Nfa NfaCollection Solver Utils)
  (libraries base angstrom bitv)
  (inline_tests)
  (preprocess

--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -476,8 +476,7 @@ let to_dfa nfa =
 let minimize nfa = nfa |> reverse |> to_dfa |> reverse |> to_dfa
 
 let invert nfa =
-  assert nfa.is_dfa;
-  let dfa = nfa |> to_dfa in
+  let dfa = if nfa.is_dfa then nfa else nfa |> to_dfa in
   let states = states dfa in
   let final = Set.diff states dfa.final in
   { final

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1,0 +1,281 @@
+module Set = Base.Set.Poly
+module Map = Base.Map.Poly
+
+type t =
+  { preds:
+      (string * string list * Ast.formula * Nfa.t * (string, int) Map.t) list
+  ; vars: (string, int) Map.t
+  ; total: int
+  ; progress: int }
+
+let ( let* ) = Result.bind
+
+let return = Result.ok
+
+let s = ref {preds= []; vars= Map.empty; total= 0; progress= 0}
+
+let collect f =
+  Ast.fold
+    (fun acc ast ->
+      match ast with
+        | Ast.Exists (xs, _) | Ast.Any (xs, _) ->
+            Set.union acc (Set.of_list xs)
+        | _ ->
+            acc )
+    (fun acc x ->
+      match x with
+        | Ast.Var x ->
+            Set.add acc x
+        | Ast.Pow (_, x) -> (
+          match x with
+            | Ast.Var x ->
+                Set.add acc ("2**" ^ x)
+            | _ ->
+                failwith "unimplemented" )
+        | _ ->
+            acc )
+    Set.empty f
+
+let _estimate f = Ast.fold (fun acc _ -> acc + 1) (fun acc _ -> acc + 1) 0 f
+
+let internal_counter = ref 0
+
+let internal s =
+  internal_counter := !internal_counter + 1;
+  !internal_counter - 1 + Map.length s.vars
+
+let teval s ast =
+  let var_exn v = Map.find_exn s.vars v in
+  let rec internals = function
+    | Ast.Const _ ->
+        1
+    | Ast.Var _ ->
+        0
+    | Ast.Add (t1, t2) ->
+        1 + internals t1 + internals t2
+    | Ast.Mul (a, t1) ->
+        let rec aux a b =
+          match a with
+            | 0 ->
+                1
+            | 1 ->
+                internals b
+            | _ -> (
+              match a mod 2 with
+                | 0 ->
+                    aux (a / 2) b
+                | 1 ->
+                    aux (a - 1) b
+                | _ ->
+                    assert false )
+        in
+        aux a t1
+    | Ast.Pow (_, _) ->
+        0
+  in
+  let deg () = Map.length s.vars + internals ast in
+  let rec teval ast =
+    match ast with
+      | Ast.Var a ->
+          let var = var_exn a in
+          (var, NfaCollection.n (deg ()))
+      | Ast.Const a ->
+          let var = internal s in
+          (var, NfaCollection.eq_const var a (deg ()))
+      | Ast.Add (l, r) ->
+          let lv, la = teval l in
+          let rv, ra = teval r in
+          let res = internal s in
+          ( res
+          , NfaCollection.add ~lhs:lv ~rhs:rv ~sum:res (deg ())
+            |> Nfa.intersect la |> Nfa.intersect ra )
+      | Ast.Mul (a, b) ->
+          let rec teval_mul a b =
+            match a with
+              | 0 ->
+                  let var = internal s in
+                  (var, NfaCollection.eq_const var 0 (deg ()))
+              | 1 ->
+                  teval b
+              | _ -> (
+                match a mod 2 with
+                  | 0 ->
+                      let tv, ta = teval_mul (a / 2) b in
+                      let res = internal s in
+                      ( res
+                      , NfaCollection.add ~lhs:tv ~rhs:tv ~sum:res (deg ())
+                        |> Nfa.intersect ta )
+                  | 1 ->
+                      let tv, ta = teval_mul (a - 1) b in
+                      let uv, ua = teval b in
+                      let res = internal s in
+                      ( res
+                      , NfaCollection.add ~lhs:tv ~rhs:uv ~sum:res (deg ())
+                        |> Nfa.intersect ta |> Nfa.intersect ua )
+                  | _ ->
+                      assert false )
+          in
+          let v, nfa = teval_mul a b in
+          (v, nfa)
+      | Ast.Pow (_, x) -> (
+        match x with
+          | Ast.Var x ->
+              (var_exn ("2**" ^ x), NfaCollection.n (deg ()))
+          | _ ->
+              failwith "unimplemented" )
+  in
+  let nfa = teval ast in
+  internal_counter := Map.length s.vars;
+  nfa
+
+let eval s ast =
+  let vars =
+    collect ast |> Set.to_list
+    |> List.mapi (fun i x -> (x, i))
+    |> Map.of_alist_exn
+  in
+  let s = {preds= s.preds; vars; total= 0; progress= 0} in
+  let deg () = Map.length s.vars in
+  let var_exn v = Map.find_exn s.vars v in
+  let rec eval ast =
+    let nfa =
+      match ast with
+        | Ast.True ->
+            NfaCollection.n 32 |> return
+        | Ast.False ->
+            NfaCollection.z 32 |> return
+        | Ast.Eq (l, r) ->
+            let lv, la = teval s l in
+            let rv, ra = teval s r in
+            NfaCollection.eq lv rv (deg ())
+            |> Nfa.intersect la |> Nfa.intersect ra
+            |> Nfa.truncate (deg ())
+            |> return
+        | Ast.Leq (l, r) ->
+            let lv, la = teval s l in
+            let rv, ra = teval s r in
+            NfaCollection.leq lv rv (deg ())
+            |> Nfa.intersect la |> Nfa.intersect ra
+            |> Nfa.truncate (deg ())
+            |> return
+        | Ast.Geq (l, r) ->
+            let lv, la = teval s l in
+            let rv, ra = teval s r in
+            NfaCollection.geq lv rv (deg ())
+            |> Nfa.intersect la |> Nfa.intersect ra
+            |> Nfa.truncate (deg ())
+            |> return
+        | Ast.Mnot f ->
+            let* nfa = eval f in
+            nfa |> Nfa.invert |> return
+        | Ast.Mand (f1, f2) ->
+            let* la = eval f1 in
+            let* ra = eval f2 in
+            Nfa.intersect la ra |> return
+        | Ast.Mor (f1, f2) ->
+            let* la = eval f1 in
+            let* ra = eval f2 in
+            Nfa.unite la ra |> return
+        | Ast.Mimpl (f1, f2) ->
+            let* la = eval f1 in
+            let* ra = eval f2 in
+            Nfa.unite (la |> Nfa.invert) ra |> return
+        | Ast.Exists (x, f) ->
+            let* nfa = eval f in
+            let x = List.map var_exn x in
+            nfa |> Nfa.project x |> return
+        | Ast.Any (x, f) ->
+            let* nfa = eval f in
+            let x = List.map var_exn x in
+            nfa |> Nfa.invert |> Nfa.project x |> Nfa.invert |> return
+        | Ast.Pred (name, args) ->
+            let* _, _pred_params, _, pred_nfa, _pred_vars =
+              List.find_opt
+                (fun (pred_name, _, _, _, _) -> pred_name = name)
+                s.preds
+              |> Option.to_result
+                   ~none:(Format.sprintf "Unknown predicate: %s" name)
+            in
+            let _args = List.map (teval s) args in
+            let nfa = pred_nfa in
+            nfa |> return
+        | Ast.Pow2 x ->
+            let _, a = teval s x in
+            a |> return
+        | _ ->
+            failwith "unimplemented"
+    in
+    nfa
+  in
+  let* res = eval ast in
+  Format.printf "\n%!";
+  (res, vars) |> return
+
+let ( let* ) = Result.bind
+
+let dump f =
+  let* nfa, _ = eval !s f in
+  Format.asprintf "%a" Nfa.format_nfa (nfa |> Nfa.minimize) |> return
+
+let list () =
+  let rec aux = function
+    | [] ->
+        ()
+    | (name, params, f, _, _) :: xs ->
+        Format.printf "%s %a = %a\n%!" name
+          (Format.pp_print_list Format.pp_print_string)
+          params Ast.pp_formula f;
+        aux xs
+  in
+  aux !s.preds
+
+let pred name params f =
+  let* nfa, vars = eval !s f in
+  s :=
+    { preds= (name, params, f, nfa, vars) :: !s.preds
+    ; total= !s.total
+    ; vars= !s.vars
+    ; progress= !s.progress };
+  return ()
+
+let proof f =
+  let* nfa, _ = f |> eval !s in
+  Nfa.run nfa |> return
+
+let%expect_test "Proof any x > 7 can be represented as a linear combination of \
+                 3 and 5" =
+  Format.printf "%b"
+    ( {|AxEyEz x = 3y + 5z | x <= 7|} |> Parser.parse_formula |> Result.get_ok
+    |> proof |> Result.get_ok );
+  [%expect {| true |}]
+
+let%expect_test "Disproof any x > 6 can be represented as a linear combination \
+                 of 3 and 5" =
+  Format.printf "%b"
+    ( {|AxEyEz x = 3y + 5z | x <= 6|} |> Parser.parse_formula |> Result.get_ok
+    |> proof |> Result.get_ok );
+  [%expect {| false |}]
+
+let%expect_test "Proof for all x exists x + 1" =
+  Format.printf "%b"
+    ( {|AxEy y = x + 1|} |> Parser.parse_formula |> Result.get_ok |> proof
+    |> Result.get_ok );
+  [%expect {| true |}]
+
+let%expect_test "Disproof for all x exists x - 1" =
+  Format.printf "%b"
+    ( {|AxEy x = y + 1|} |> Parser.parse_formula |> Result.get_ok |> proof
+    |> Result.get_ok );
+  [%expect {| false |}]
+
+let%expect_test "Proof simple existential formula" =
+  Format.printf "%b"
+    ( {|ExEy 15 = x + y & y <= 10|} |> Parser.parse_formula |> Result.get_ok
+    |> proof |> Result.get_ok );
+  [%expect {| true |}]
+
+let%expect_test "Proof simple any quantified formula" =
+  Format.printf "%b"
+    ( {|Ax x = 2 | ~(x = 2)|} |> Parser.parse_formula |> Result.get_ok |> proof
+    |> Result.get_ok );
+  [%expect {| true |}]

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,0 +1,7 @@
+val list : unit -> unit
+
+val pred : string -> string list -> Ast.formula -> (unit, string) result
+
+val dump : Ast.formula -> (string, string) result
+
+val proof : Ast.formula -> (bool, string) result


### PR DESCRIPTION
This patch adds an implementation of the basic Presburger Arithmetic solver. The procedure is based on a classical automata-based approach for proving Presburger arithmetic statements.

For each atomic formula an automaton is built and then they're intersected/unioned corresponding to the atomic formula logical connectives.

Now, when running the solver, the REPL is provided, supporting a variety of basic commands:
* `eval` for proving/disproving statements.
* `parse` for dumping the AST for the formula.
* `dump` for drawing the NFA using GraphViz.

Closes #12