### PR TITLE
nfa: fix minimization algorithm

### DIFF
--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -473,7 +473,7 @@ let to_dfa nfa =
   let transitions = Array.of_list transitions in
   {final; start= Set.singleton 0; transitions; deg= nfa.deg; is_dfa= true}
 
-let minimize nfa = nfa |> reverse |> to_dfa |> reverse |> to_dfa
+let minimize nfa = nfa |> to_dfa |> reverse |> to_dfa |> reverse |> to_dfa
 
 let invert nfa =
   let dfa = if nfa.is_dfa then nfa else nfa |> to_dfa in


### PR DESCRIPTION
This patch fixes the NFA minimization algorithm. NFA minimization is based on Brzozowski's algorithm consisting of two consequent automaton reversion and determinization. Turns out it works only for DFAs. Thus, make the input automaton deterministic first.