### PR TITLE
optimizer: add quantifier de-prenexing

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name MacadamiaSolver)
- (name main)
+ (name mandms)
  (libraries lib))

--- a/bin/mandms.ml
+++ b/bin/mandms.ml
@@ -34,9 +34,9 @@ let exec line = function
       | Error msg ->
           Format.printf "Error: %s\n\n%!" msg )
   | Ast.Parse f ->
-      Format.printf "Formula AST: %a\n%!" Ast.pp_formula f
-  (* TODO: Support for optimizer. *)
-  (* Format.printf "Optimized AST: %a\n\n%!" Ast.pp_formula f *)
+      Format.printf "Formula AST: %a\n%!" Ast.pp_formula f;
+      Format.printf "Optimized AST: %a\n\n%!" Ast.pp_formula
+        (f |> Optimizer.optimize)
   | Ast.List ->
       Solver.list ()
   | Ast.Help ->

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name lib)
- (modules Ast Parser Nfa NfaCollection Solver Utils)
+ (modules Ast Optimizer Parser Nfa NfaCollection Solver Utils)
  (libraries base angstrom bitv)
  (inline_tests)
  (preprocess

--- a/lib/optimizer.ml
+++ b/lib/optimizer.ml
@@ -1,0 +1,60 @@
+let contains var f =
+  Ast.for_some
+    (function Ast.Exists (a, _) | Ast.Any (a, _) -> a = var | _ -> false)
+    (function Ast.Var a -> List.mem a var | _ -> false)
+    f
+
+let move_quantifiers_closer formula =
+  let rec aux f =
+    let f' =
+      Ast.map
+        (function
+          | (Ast.Exists (x, f') | Ast.Any (x, f')) as f -> (
+              let quantifier_ast = Ast.quantifier_ast_exn f in
+              match f' with
+                | Ast.Mor (f1, f2)
+                | Ast.Mand (f1, f2)
+                | Ast.Miff (f1, f2)
+                | Ast.Mimpl (f1, f2) -> (
+                    let binconj_ast = Ast.binconj_ast_exn f' in
+                    let l1 = contains x f1 in
+                    let l2 = contains x f2 in
+                    match (l1, l2) with
+                      | true, true ->
+                          f
+                      | false, false ->
+                          f'
+                      | true, false ->
+                          binconj_ast (quantifier_ast x f1) f2
+                      | false, true ->
+                          binconj_ast f1 (quantifier_ast x f2) )
+                | _ ->
+                    if contains x f' then f else f' )
+          | _ as f ->
+              f )
+        Fun.id f
+    in
+    if f' = f then f' else aux f'
+  in
+  aux formula
+
+let quantifier_union f =
+  Ast.map
+    (function
+      | Ast.Exists (x, f') as f -> (
+        match f' with
+          | Ast.Exists (y, f'') ->
+              Ast.exists (List.append x y) f''
+          | _ ->
+              f )
+      | Ast.Any (x, f') as f -> (
+        match f' with
+          | Ast.Any (y, f'') ->
+              Ast.any (List.append x y) f''
+          | _ ->
+              f )
+      | _ as f ->
+          f )
+    Fun.id f
+
+let optimize f = f |> move_quantifiers_closer |> quantifier_union

--- a/lib/optimizer.mli
+++ b/lib/optimizer.mli
@@ -1,0 +1,1 @@
+val optimize : Ast.formula -> Ast.formula


### PR DESCRIPTION
This patch adds support for basic quantifier de-prenexing. When using the automaton approach for evaluating Presburger Arithmetic expressions it's better to de-prenex the quantifiers (move them to the bottom part of the statement AST) to evaluate NFA projections earlier.

E.g. it's simpler to build an automaton for:
```
(Ex P1(x)) & (Ey P2(y)) & (Ez P3(z))
```

Than to build an NFA for:
```
ExEyEz P1(x) & P2(y) & P3(z)
```

When you build NFAs using the classical bottom-top decision procedure.