### PR TITLE
solver: add evalsemenov stub

### DIFF
--- a/bin/mandms.ml
+++ b/bin/mandms.ml
@@ -12,6 +12,8 @@ let exec line = function
             Format.printf "Result: %b\n\n%!" res
         | Error msg ->
             Format.printf "Error: %s\n\n%!" msg )
+  | Ast.EvalSemenov _f ->
+      Format.printf "Semenov arithmetic is not yet supported\n\n%!"
   | Ast.Dump f -> (
     match Solver.dump f with
       | Ok s ->

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -30,11 +30,11 @@ type formula =
   | Miff of formula * formula
   | Exists of varname list * formula
   | Any of varname list * formula
-  | Pow2 of term
 
 type stmt =
   | Def of string * varname list * formula
   | Eval of formula
+  | EvalSemenov of formula
   | Dump of formula
   | Parse of formula
   | List
@@ -85,6 +85,8 @@ let any x y = Any (x, y)
 let def x p f = Def (x, p, f)
 
 let eval f = Eval f
+
+let eval_semenov f = EvalSemenov f
 
 let dump f = Dump f
 
@@ -147,8 +149,6 @@ let rec pp_formula ppf = function
            ~pp_sep:(fun ppf () -> Format.fprintf ppf " ")
            Format.pp_print_string )
         a pp_formula b
-  | Pow2 a ->
-      Format.fprintf ppf "(Pow2 %a)" pp_term a
 
 let quantifier_ast_exn = function
   | Exists _ ->
@@ -208,8 +208,6 @@ let fold ff ft acc f =
         ff (foldf acc f1) f
     | Pred (_, _) as f ->
         ff acc f
-    | _ ->
-        failwith "Unimplemented"
   in
   foldf acc f
 
@@ -267,7 +265,5 @@ let map ff ft f =
         Any (a, mapf f1) |> ff
     | Pred (_, _) as f ->
         f |> ff
-    | _ ->
-        failwith "Unimplemented"
   in
   mapf f

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -30,11 +30,11 @@ type formula =
   | Miff of formula * formula
   | Exists of varname list * formula
   | Any of varname list * formula
-  | Pow2 of term
 
 type stmt =
   | Def of string * varname list * formula
   | Eval of formula
+  | EvalSemenov of formula
   | Dump of formula
   | Parse of formula
   | List
@@ -85,6 +85,8 @@ val any : varname list -> formula -> formula
 val def : string -> varname list -> formula -> stmt
 
 val eval : formula -> stmt
+
+val eval_semenov : formula -> stmt
 
 val dump : formula -> stmt
 

--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -500,7 +500,8 @@ let to_dfa nfa =
 let minimize nfa = nfa |> to_dfa |> reverse |> to_dfa |> reverse |> to_dfa
 
 let invert nfa =
-  let dfa = if nfa.is_dfa then nfa else nfa |> to_dfa in
+  (* We need complete DFA here, to_dfa() makes a complete DFA thus we're using it. *)
+  let dfa = nfa |> to_dfa in
   let states = states dfa in
   let final = Set.diff states dfa.final in
   { final

--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -199,7 +199,6 @@ let remove_unreachable nfa =
 
 let update_final_states_nfa nfa =
   let reversed_transitions = nfa.transitions |> Graph.reverse in
-  Printf.printf "\n%!";
   let final =
     let visited = Array.make (length nfa) false in
     let rec bfs reachable = function

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -8,6 +8,8 @@ let is_whitespace = function ' ' | '\t' | '\n' | '\r' -> true | _ -> false
 
 let whitespace = take_while is_whitespace
 
+let whitespace1 = take_while1 is_whitespace
+
 let is_digit = function '0' .. '9' -> true | _ -> false
 
 let const = take_while1 is_digit >>| int_of_string >>| Ast.const
@@ -90,17 +92,17 @@ let formula =
 let kw kw ast = string kw *> whitespace *> return ast
 
 let kw1 kw ast p1 =
-  let* _ = string kw <* whitespace in
+  let* _ = string kw <* whitespace1 in
   let* p1 = p1 in
   ast p1 |> return
 
 let kw2 kw ast p1 p2 =
-  let* _ = string kw <* whitespace in
+  let* _ = string kw <* whitespace1 in
   let* p1 = p1 in
   ast p1 p2
 
 let kw3 kw ast p1 p2 p3 =
-  let* _ = string kw <* whitespace in
+  let* _ = string kw <* whitespace1 in
   let* p1 = p1 in
   let* p2 = p2 in
   let* p3 = p3 in
@@ -114,6 +116,7 @@ let def =
 
 let stmt =
   kw1 "eval" Ast.eval formula
+  <|> kw1 "evalsemenov" Ast.eval_semenov formula
   <|> kw3 "let" Ast.def (ident <* whitespace)
         (many (whitespace *> ident))
         (whitespace *> char '=' *> whitespace *> formula)

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -5,3 +5,5 @@ val pred : string -> string list -> Ast.formula -> (unit, string) result
 val dump : Ast.formula -> (string, string) result
 
 val proof : Ast.formula -> (bool, string) result
+
+val proof_semenov : Ast.formula -> (bool, string) result


### PR DESCRIPTION
This is a patchset with two distinct patches:

The first patch adds stub for statement `evalsemenov`.
It's going to be used to evaluate existential Semenov arithmetic
statements. Semenov arithmetic are similar to PrA except it also
has 2**x as a functional symbol.

The second patch fixes a bug in an NFA `invert()` call making the
 call no longer require complete DFA as an input.