### PR TITLE
solver: support less/greater than operators

### DIFF
--- a/lib/NfaCollection.ml
+++ b/lib/NfaCollection.ml
@@ -54,6 +54,22 @@ let leq lhs rhs =
 
 let geq x y = leq y x
 
+let lt lhs rhs =
+  Nfa.create_nfa
+    ~transitions:
+      [ (0, 0b01, 1)
+      ; (0, 0b11, 0)
+      ; (0, 0b10, 0)
+      ; (0, 0b00, 0)
+      ; (1, 0b11, 1)
+      ; (1, 0b01, 1)
+      ; (1, 0b00, 1)
+      ; (1, 0b10, 0) ]
+    ~start:[0] ~final:[1] ~vars:[lhs; rhs]
+    ~deg:(max lhs rhs + 1)
+
+let gt x y = lt y x
+
 let torename var a c =
   let trans1 =
     List.init (a + c - 1) Fun.id |> List.map (fun x -> (x, 0b0, x + 1))

--- a/lib/NfaCollection.mli
+++ b/lib/NfaCollection.mli
@@ -14,4 +14,8 @@ val leq : varpos -> varpos -> Nfa.t
 
 val geq : varpos -> varpos -> Nfa.t
 
+val lt : varpos -> varpos -> Nfa.t
+
+val gt : varpos -> varpos -> Nfa.t
+
 val torename : varpos -> int -> int -> Nfa.t

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -99,7 +99,6 @@ let teval s ast =
               failwith "unimplemented" )
   in
   let nfa = teval ast in
-  internal_counter := Map.length s.vars;
   nfa
 
 let eval s ast =
@@ -111,6 +110,7 @@ let eval s ast =
   let s = {preds= s.preds; vars; total= 0; progress= 0} in
   let deg () = Map.length s.vars in
   let var_exn v = Map.find_exn s.vars v in
+  let reset_internals () = internal_counter := Map.length s.vars in
   let rec eval ast =
     let nfa =
       match ast with
@@ -121,18 +121,21 @@ let eval s ast =
         | Ast.Eq (l, r) ->
             let lv, la = teval s l in
             let rv, ra = teval s r in
+            reset_internals ();
             NfaCollection.eq lv rv |> Nfa.intersect la |> Nfa.intersect ra
             |> Nfa.truncate (deg ())
             |> return
         | Ast.Leq (l, r) ->
             let lv, la = teval s l in
             let rv, ra = teval s r in
+            reset_internals ();
             NfaCollection.leq lv rv |> Nfa.intersect la |> Nfa.intersect ra
             |> Nfa.truncate (deg ())
             |> return
         | Ast.Geq (l, r) ->
             let lv, la = teval s l in
             let rv, ra = teval s r in
+            reset_internals ();
             NfaCollection.geq lv rv |> Nfa.intersect la |> Nfa.intersect ra
             |> Nfa.truncate (deg ())
             |> return
@@ -258,3 +261,21 @@ let%expect_test "Proof simple any quantified formula" =
     ( {|Ax x = 2 | ~(x = 2)|} |> Parser.parse_formula |> Result.get_ok |> proof
     |> Result.get_ok );
   [%expect {| true |}]
+
+let%expect_test "Proof 2 <= 3" =
+  Format.printf "%b"
+    ( {|2 <= 3|} |> Parser.parse_formula |> Result.get_ok |> proof
+    |> Result.get_ok );
+  [%expect {| true |}]
+
+let%expect_test "Proof zero is the least" =
+  Format.printf "%b"
+    ( {|Ax x >= 0|} |> Parser.parse_formula |> Result.get_ok |> proof
+    |> Result.get_ok );
+  [%expect {| true |}]
+
+let%expect_test "Disproof 3 >= 15" =
+  Format.printf "%b"
+    ( {|3 >= 15|} |> Parser.parse_formula |> Result.get_ok |> proof
+    |> Result.get_ok );
+  [%expect {| false |}]


### PR DESCRIPTION
The first patch adds support for `<` and `>` operators. They behave 
like a syntax sugar, i.e. `x > y <-> x >= y + 1`.

The second patch fixes problems that occur when solving simple statements
with the same amount of internal variables. E.g. `2 <= 3`.

The problem was in the fact the NFAs for their values used the same
internal variable indices in the vectors over the labels. I.e. in
case of `2 <= 3` it's both `0` thus the intersection of the automata
gave wrong results.

This patch fixes it by making the solver reset the internal counter after
solving the atomic formula.