### PR TITLE
solver: support existential Semenov arithmetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _build/
+debugs/
+dumps/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MacadamiaSolver
 
-__MacadamiaSolver__ (or simple __MandmS__ as an acronym for MacANDaMia solver) is a theorem prover (SMT-solver) in Presburger Arithmetic based on the finite-automata approach for deciding.
+__MacadamiaSolver__ (or simple __MandmS__ as an acronym for MacANDaMia solver) is a theorem prover (SMT-solver) in Presburger Arithmetic based on the finite-automata approach for deciding. It also supports [existential Semёnov arithmetic](https://arxiv.org/abs/2306.14593) (i.e. existential theory `<N, 2**x, +, =>`).
 
 ## Dependencies
 To build the project you'll need these dependencies to be installed:
@@ -37,6 +37,7 @@ Commands supported by the REPL and their semantics:
 - `let <name> <params...> = <FOL formula>` - define a new predicate.
 - `list` - list existing predicates.
 - `eval <formula>` - prove a theorem.
+- `evalsemenov <formula>` - prove an existential Semёnov arithmetic theorem.
 - `dump <FOL formula>` - display the automaton for the desired FOL formula using GraphViz.
 - `parse <FOL formula>` - display the AST tree for the FOL formula.
 - `help` - display help information.
@@ -72,19 +73,24 @@ var ::= [a-zA-Z_][a-zA-Z_0-9]*
 const ::= [0-9]+
 ```
 
-Example usage:
+Example usages:
 ```
-eval Ax Ey x = y + 1
+> eval Ax Ey x = y + 1
+  Result: true
+
+> let even x = Ey x = 2y
+> eval AxAyAz x + y = z & even(x) & even(y) -> even(z + 1)
+  Result: false
+
+> eval AxAyAz x + y = z & even(x) & even(y) -> even(z)
+  Result: true
+
+> evalsemenov 2**x = 2**y + 2**z + 7
+  Result: true
 ```
 
-Output:
-```
-Result: true
-```
 
 ## Future development
 
 Our future plans include:
-- Supporting predicates.
-- Implementing the prover for the existential Semёnov arithmetic (`<N, 2**x, +, <, ...>`).
 - Supporting SMT-Lib for evaluating benchmarks

--- a/bin/mandms.ml
+++ b/bin/mandms.ml
@@ -10,7 +10,11 @@ let exec line = function
     (match res with
      | Ok res -> Format.printf "Result: %b\n\n%!" res
      | Error msg -> Format.printf "Error: %s\n\n%!" msg)
-  | Ast.EvalSemenov _f -> Format.printf "Semenov arithmetic is not yet supported\n\n%!"
+  | Ast.EvalSemenov f ->
+    let res = Solver.proof_semenov f in
+    (match res with
+     | Ok res -> Format.printf "Result: %b\n\n%!" res
+     | Error msg -> Format.printf "Error: %s\n\n%!" msg)
   | Ast.Dump f ->
     (match Solver.dump f with
      | Ok s ->
@@ -41,15 +45,17 @@ let exec line = function
 
 let () =
   let rec aux () =
-    let line = read_line () in
-    let stmt = Parser.parse line in
-    match stmt with
-    | Ok stmt ->
-      exec line stmt;
+    try
+      Format.printf "> %!";
+      let line = read_line () in
+      Format.printf "  %!";
+      let stmt = Parser.parse line in
+      (match stmt with
+       | Ok stmt -> exec line stmt
+       | Error msg -> Format.printf "Error: %s\n\n%!" msg);
       aux ()
-    | Error msg ->
-      Format.printf "Error: %s\n\n%!" msg;
-      aux ()
+    with
+    | End_of_file -> ()
   in
   aux ()
 ;;

--- a/lib/NfaCollection.mli
+++ b/lib/NfaCollection.mli
@@ -10,3 +10,6 @@ val geq : varpos -> varpos -> Nfa.t
 val lt : varpos -> varpos -> Nfa.t
 val gt : varpos -> varpos -> Nfa.t
 val torename : varpos -> int -> int -> Nfa.t
+val torename2 : int -> int -> Nfa.t
+val power_of_two : int -> Nfa.t
+val mul : res:varpos -> lhs:int -> rhs:varpos -> Nfa.t

--- a/lib/debug.ml
+++ b/lib/debug.ml
@@ -1,0 +1,51 @@
+let nfa_cnt = ref 0
+let flag () = Sys.getenv_opt "MANDAMS_DEBUG" |> Option.is_some
+
+let fmt =
+  if flag ()
+  then Format.formatter_of_out_channel Stdio.stderr
+  else
+    Format.formatter_of_out_functions
+      { out_string = (fun _ _ _ -> ())
+      ; out_flush = (fun _ -> ())
+      ; out_newline = (fun _ -> ())
+      ; out_spaces = (fun _ -> ())
+      ; out_indent = (fun _ -> ())
+      }
+;;
+
+let printf str = Format.fprintf fmt (str ^^ "%!")
+let printfln str = Format.fprintf fmt (str ^^ "\n%!")
+
+let dump_nfa ?msg ?vars format_nfa nfa =
+  if flag ()
+  then (
+    let ( !< ) a = Format.sprintf a in
+    let name =
+      nfa_cnt := !nfa_cnt + 1;
+      Format.sprintf "%d" !nfa_cnt
+    in
+    let subdir = string_of_int (Unix.getpid ()) in
+    let supdir = "debugs" in
+    Sys.command (!<{|mkdir -p "%s"/"%s"|} supdir subdir) |> ignore;
+    let dir = !<"%s/%s" supdir subdir in
+    let dot_file = !<"%s/%s.dot" dir name in
+    let svg_file = !<"%s/%s.svg" dir name in
+    let oc = open_out dot_file in
+    let command = Format.sprintf {|dot -Tsvg "%s" > "%s"|} dot_file svg_file in
+    Format.asprintf "%a" format_nfa nfa |> Printf.fprintf oc "%s";
+    close_out oc;
+    Sys.command command |> ignore;
+    (match msg with
+     | Some msg -> printfln msg svg_file
+     | None -> ());
+    match vars with
+    | Some vars ->
+      Format.pp_print_list
+        ~pp_sep:(fun fmt () -> Format.fprintf fmt "\n")
+        (fun fmt (a, b) -> Format.fprintf fmt "%d -> %s" b a)
+        fmt
+        vars;
+      printfln "\n"
+    | None -> ())
+;;

--- a/lib/debug.mli
+++ b/lib/debug.mli
@@ -1,0 +1,11 @@
+val flag : unit -> bool
+val fmt : Format.formatter
+val printf : ('a, Format.formatter, unit) format -> 'a
+val printfln : ('a, Format.formatter, unit) format -> 'a
+
+val dump_nfa
+  :  ?msg:(string -> unit, Format.formatter, unit, unit, unit, unit) format6
+  -> ?vars:(string * int) list
+  -> (Format.formatter -> 'a -> unit)
+  -> 'a
+  -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name lib)
- (modules Ast Optimizer Parser Nfa NfaCollection Solver Utils)
- (libraries base angstrom bitv)
+ (modules Ast Optimizer Parser Nfa NfaCollection Solver Utils Debug)
+ (libraries base angstrom bitv unix)
  (inline_tests)
  (preprocess
   (pps ppx_variants_conv ppx_inline_test ppx_assert ppx_expect)))

--- a/lib/nfa.mli
+++ b/lib/nfa.mli
@@ -33,3 +33,7 @@ val minimize : t -> t
 val invert : t -> t
 val format_nfa : Format.formatter -> t -> unit
 val remove_unreachable : t -> t
+val find_c_d : t -> (int, int) Map.t -> (int * int) list
+val get_exponent_sub_nfa : t -> res:int -> temp:int -> t
+val chrobak : t -> (int * int) list
+val get_chrobaks_sub_nfas : t -> res:deg -> temp:deg -> (t * (int * int) list) list

--- a/lib/optimizer.ml
+++ b/lib/optimizer.ml
@@ -39,6 +39,58 @@ let move_quantifiers_closer formula =
   aux formula
 ;;
 
+let get_rid_of_forall formula =
+  Ast.map
+    (function
+      | Ast.Any (x, f') -> Ast.mnot (Ast.exists x (Ast.mnot f'))
+      | _ as f -> f)
+    Fun.id
+    formula
+;;
+
+let apply_demourgan_law formula =
+  let rec aux f =
+    let f' =
+      Ast.map
+        (function
+          | Ast.Mnot f' as f ->
+            (match f' with
+             | Ast.Mor (f1, f2) -> Ast.mand (Ast.mnot f1) (Ast.mnot f2)
+             | Ast.Mand (f1, f2) -> Ast.mor (Ast.mnot f1) (Ast.mnot f2)
+             | _ -> f)
+          | _ as f -> f)
+        Fun.id
+        f
+    in
+    if f' = f then f' else aux f'
+  in
+  aux formula
+;;
+
+let simplify_negation formula =
+  let rec aux f =
+    let f' =
+      Ast.map
+        (function
+          | Ast.Mnot f' as f ->
+            (match f' with
+             | Ast.Mnot f'' -> f''
+             | Ast.Leq (f1, f2) -> Ast.gt f1 f2
+             | Ast.Geq (f1, f2) -> Ast.lt f1 f2
+             | Ast.Gt (f1, f2) -> Ast.leq f1 f2
+             | Ast.Lt (f1, f2) -> Ast.geq f1 f2
+             | Ast.Eq (f1, f2) -> Ast.neq f1 f2
+             | Ast.Neq (f1, f2) -> Ast.eq f1 f2
+             | _ -> f)
+          | _ as f -> f)
+        Fun.id
+        f
+    in
+    if f' = f then f' else aux f'
+  in
+  aux formula
+;;
+
 let quantifier_union f =
   Ast.map
     (function
@@ -55,4 +107,75 @@ let quantifier_union f =
     f
 ;;
 
-let optimize f = f |> move_quantifiers_closer |> quantifier_union
+let optimize f =
+  f
+  |> move_quantifiers_closer
+  |> quantifier_union
+  |> get_rid_of_forall
+  |> apply_demourgan_law
+  |> simplify_negation
+;;
+
+let%expect_test "Move existential quantifiers closer" =
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    ({|ExEyEz x + y = 2 & z = 15|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> move_quantifiers_closer);
+  [%expect {| ((Ex (Ey ((x + y) = 2))) & (Ez (z = 15))) |}]
+;;
+
+let%expect_test "Move for all quantifiers closer" =
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    ({|AxAy y = 2 | y = 3 | y = 4 | x = 2|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> move_quantifiers_closer);
+  [%expect {| ((Ay (((y = 2) | (y = 3)) | (y = 4))) | (Ax (x = 2))) |}]
+;;
+
+let%expect_test "Existential quantifier union" =
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    ({|ExEyEz x + y + z = 15|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> quantifier_union);
+  [%expect {| (Ex y z (((x + y) + z) = 15)) |}]
+;;
+
+let%expect_test "For all quantifier union" =
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    ({|AxAyAz x + y + z = 15|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> quantifier_union);
+  [%expect {| (Ax y z (((x + y) + z) = 15)) |}]
+;;
+
+let%expect_test "Replace for all with existential quantifiers" =
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    ({|Ax x >= 0|} |> Parser.parse_formula |> Result.get_ok |> get_rid_of_forall);
+  [%expect {| (~ (Ex (~ (x >= 0)))) |}]
+;;
+
+let%expect_test "Simplify negations" =
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    ({|~(a = 1) & ~(b > 1) & ~(c < 1) & ~(d >= 1) & ~(e <= 1) & ~(f != 1) & ~(~(g = 1)) & ~(h = 1 -> i = 2)|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> simplify_negation);
+  [%expect
+    {| ((((((((a != 1) & (b <= 1)) & (c >= 1)) & (d < 1)) & (e > 1)) & (f = 1)) & (g = 1)) & (~ ((h = 1) -> (i = 2)))) |}]
+;;

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -85,7 +85,9 @@ let teval s ast =
       v, nfa
     | Ast.Pow (_, x) ->
       (match x with
-       | Ast.Var x -> var_exn ("2**" ^ x), NfaCollection.n ()
+       | Ast.Var x ->
+         let var = var_exn ("2**" ^ x) in
+         var, NfaCollection.power_of_two var
        | _ -> failwith "unimplemented")
   in
   let nfa = teval ast in
@@ -152,7 +154,7 @@ let eval s ast =
         |> return
       | Ast.Mnot f ->
         let* nfa = eval f in
-        nfa |> Nfa.invert |> return
+        nfa |> Nfa.invert |> Nfa.minimize |> return
       | Ast.Mand (f1, f2) ->
         let* la = eval f1 in
         let* ra = eval f2 in
@@ -168,11 +170,11 @@ let eval s ast =
       | Ast.Exists (x, f) ->
         let* nfa = eval f in
         let x = List.map var_exn x in
-        nfa |> Nfa.project x |> return
+        nfa |> Nfa.project x |> Nfa.minimize |> return
       | Ast.Any (x, f) ->
         let* nfa = eval f in
         let x = List.map var_exn x in
-        nfa |> Nfa.invert |> Nfa.project x |> Nfa.invert |> return
+        nfa |> Nfa.invert |> Nfa.project x |> Nfa.invert |> Nfa.minimize |> return
       | Ast.Pred (name, args) ->
         let* _, pred_params, _, pred_nfa, pred_vars =
           List.find_opt (fun (pred_name, _, _, _, _) -> pred_name = name) s.preds
@@ -241,11 +243,6 @@ let proof f =
          f)
       ""
   in
-  let* nfa, _ = f |> eval !s in
-  Nfa.run nfa |> return
-;;
-
-let proof_semenov f =
   let* nfa, _ = f |> eval !s in
   Nfa.run nfa |> return
 ;;
@@ -427,4 +424,464 @@ let%expect_test "Proof a number is even iff it's not odd" =
      |> Result.get_ok);
   s := default_s ();
   [%expect {| true |}]
+;;
+
+let log2 n =
+  let rec helper acc = function
+    | 0 -> acc
+    | n -> helper (acc + 1) (n / 2)
+  in
+  helper (-1) n
+;;
+
+let _pow2 n =
+  match n with
+  | 0 -> 1
+  | n -> List.init (n - 1) (Fun.const 2) |> List.fold_left ( * ) 1
+;;
+
+let gen_list_n n =
+  let rec helper acc = function
+    | 0 -> [ 0 ]
+    | n -> helper (n :: acc) (n - 1)
+  in
+  helper [] n |> List.rev
+;;
+
+let is_exp var = String.starts_with ~prefix:"2**" var
+
+let get_exp var =
+  assert (is_exp var);
+  String.sub var 3 (String.length var - 3)
+;;
+
+let decide_order vars =
+  let rec perms list =
+    let a =
+      if List.length list <> 0
+      then
+        List.mapi
+          (fun i el ->
+             let list = List.filteri (fun j _ -> i <> j) list in
+             List.map (fun list' -> el :: list') (perms list))
+          list
+        |> List.concat
+      else [ [] ]
+    in
+    a
+  in
+  let perms = perms (Map.keys vars) in
+  perms
+  |> List.filter (fun perm ->
+    Base.List.for_alli
+      ~f:(fun i var ->
+        if is_exp var
+        then (
+          let x = get_exp var in
+          List.find_index (fun y -> x = y) perm |> Option.value ~default:9999999 > i)
+        else true)
+      perm)
+  |> List.filter (fun perm ->
+    Base.List.for_alli
+      ~f:(fun exi ex ->
+        if is_exp ex
+        then (
+          let x = get_exp ex in
+          match List.find_index (fun x' -> x = x') perm with
+          | Some xi ->
+            Base.List.for_alli
+              ~f:(fun eyi ey ->
+                if is_exp ey && eyi > exi
+                then (
+                  let y = get_exp ey in
+                  match List.find_index (fun y' -> y = y') perm with
+                  | Some yi -> yi > xi
+                  | None -> true)
+                else true)
+              perm
+          | None -> true)
+        else true)
+      perm)
+;;
+
+let nfa_for_exponent2 s var var2 chrob =
+  chrob
+  |> List.map (fun (a, c) ->
+    let old_internal_counter = !internal_counter in
+    let a_var = internal s in
+    let var2_plus_a = internal s in
+    let t = internal s in
+    let c_mul_t = internal s in
+    Debug.printfln "nfa_for_exponent2: internal_counter=%d" !internal_counter;
+    Debug.printfln "[ var2_plus_a; c_mul_t; t ] = [%d; %d; %d]" var2_plus_a c_mul_t t;
+    let nfa =
+      Nfa.project
+        [ var2_plus_a; c_mul_t; t; a_var ]
+        (Nfa.intersect
+           (NfaCollection.add ~lhs:var2_plus_a ~rhs:c_mul_t ~sum:var)
+           (Nfa.intersect
+              (Nfa.intersect
+                 (NfaCollection.add ~sum:var2_plus_a ~lhs:var2 ~rhs:a_var)
+                 (NfaCollection.eq_const a_var a))
+              (NfaCollection.mul ~res:c_mul_t ~lhs:c ~rhs:t)))
+    in
+    Debug.dump_nfa ~msg:"nfa_for_exponent2 output nfa: %s" Nfa.format_nfa nfa;
+    internal_counter := old_internal_counter;
+    nfa)
+;;
+
+let _ = nfa_for_exponent2
+
+let nfa_for_exponent s var newvar chrob =
+  chrob
+  |> List.concat_map (fun (a, c) ->
+    if c = 0
+    then
+      List.init (a + 10) (( + ) a)
+      |> List.map (fun x ->
+        let log = log2 x in
+        x - log, log, 0)
+      |> List.filter (fun (t, _, _) -> t = a)
+    else c |> gen_list_n |> List.map (fun d -> a, d, c))
+  |> List.map (fun (a, d, c) ->
+    let old_internal_counter = !internal_counter in
+    let a_plus_d = internal s in
+    let t = internal s in
+    let c_mul_t = internal s in
+    let internal = internal s in
+    let nfa =
+      Nfa.project
+        [ a_plus_d; c_mul_t; t ]
+        (Nfa.intersect
+           (NfaCollection.add ~lhs:a_plus_d ~rhs:c_mul_t ~sum:var)
+           (Nfa.intersect
+              (NfaCollection.eq_const a_plus_d (a + d))
+              (NfaCollection.mul ~res:c_mul_t ~lhs:c ~rhs:t)))
+    in
+    let n =
+      List.init (a + 2) (( + ) a) |> List.filter (fun x -> x - log2 x >= a) |> List.hd
+    in
+    let newvar_nfa = NfaCollection.torename newvar d c in
+    let geq_nfa =
+      NfaCollection.geq var internal |> Nfa.intersect (NfaCollection.eq_const internal n)
+    in
+    let nfa =
+      nfa
+      |> Nfa.intersect newvar_nfa
+      |> Nfa.minimize
+      |> Nfa.intersect geq_nfa
+      |> Nfa.project [ internal ]
+    in
+    internal_counter := old_internal_counter;
+    nfa)
+;;
+
+let proof_semenov formula =
+  let* nfa, vars = eval !s formula in
+  let nfa = Nfa.minimize nfa in
+  Debug.dump_nfa
+    ~msg:"Minimized original nfa: %s"
+    ~vars:(Map.to_alist vars)
+    Nfa.format_nfa
+    nfa;
+  let s = { !s with vars } in
+  let get_deg x = Map.find_exn vars x in
+  let orders : string list list = decide_order vars in
+  let first x =
+    x
+    |> Seq.find (function
+      | Ok true | Error _ -> true
+      | Ok false -> false)
+    |> function
+    | Some x -> x
+    | None -> Ok false
+  in
+  let rec proof_order nfa order =
+    match order with
+    | [] -> nfa |> Nfa.run
+    | x :: tl ->
+      Debug.dump_nfa ~msg:"Nfa inside proof_order: %s" Nfa.format_nfa nfa;
+      (match is_exp x with
+       | false -> proof_order (Nfa.project [ get_deg x ] nfa) tl
+       | true ->
+         (match List.length tl with
+          | 0 -> nfa |> Nfa.project [ get_deg x ] |> Nfa.run
+          | _ ->
+            let deg () = Map.length s.vars in
+            let old_counter = !internal_counter in
+            let inter = internal s in
+            let next = List.nth tl 0 in
+            let temp = if is_exp next then get_deg next else inter in
+            let x' = get_exp x in
+            let zero_nfa =
+              Nfa.intersect
+                (NfaCollection.eq_const (Map.find_exn s.vars x) 1)
+                (NfaCollection.eq_const (Map.find_exn s.vars x') 0)
+              |> Nfa.truncate (deg ())
+            in
+            let zero_nfa =
+              nfa |> Nfa.intersect zero_nfa |> Nfa.project [ Map.find_exn s.vars x ]
+            in
+            Debug.printf "Zero nfa for %s: " x;
+            Debug.dump_nfa ~msg:"%s" Nfa.format_nfa zero_nfa;
+            if proof_order zero_nfa tl
+            then true
+            else (
+              let nfa =
+                if is_exp next
+                then nfa
+                else nfa |> Nfa.intersect (NfaCollection.torename2 (get_deg x') inter)
+              in
+              let t = Nfa.get_chrobaks_sub_nfas nfa ~res:(get_deg x) ~temp in
+              let result =
+                t
+                |> List.to_seq
+                |> Seq.flat_map (fun (nfa, chrobak) ->
+                  let a =
+                    (match is_exp next with
+                     | false -> nfa_for_exponent s (Map.find_exn s.vars x') inter chrobak
+                     | true ->
+                       let y = get_exp next in
+                       Debug.dump_nfa
+                         ~msg:"close to nfa_for_exponent2 - intersection nfa: %s"
+                         Nfa.format_nfa
+                         nfa;
+                       nfa_for_exponent2
+                         s
+                         (Map.find_exn s.vars x')
+                         (Map.find_exn s.vars y)
+                         chrobak)
+                    |> List.map (Nfa.intersect nfa)
+                  in
+                  a |> List.to_seq)
+                |> Seq.map (Nfa.project [ get_deg x; inter ])
+                |> Seq.map (fun nfa -> proof_order (Nfa.minimize nfa) tl)
+                |> Seq.exists Fun.id
+              in
+              internal_counter := old_counter;
+              result)))
+  in
+  orders
+  |> List.to_seq
+  |> Seq.map (fun order ->
+    Debug.printfln
+      "Trying order %a"
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.fprintf ppf " <= ")
+         Format.pp_print_string)
+      (order |> List.rev);
+    let len = List.length order in
+    let* nfa =
+      if len <= 1
+      then Ok nfa
+      else
+        let* order_nfa, _ =
+          eval
+            s
+            (Seq.zip
+               (order |> List.to_seq |> Seq.take (len - 1))
+               (order |> List.to_seq |> Seq.drop 1)
+             |> Seq.map (fun (x, y) -> Ast.Geq (Ast.Var x, Ast.Var y))
+             |> List.of_seq
+             |> function
+             | [] -> failwith ""
+             | h :: tl -> List.fold_left Ast.mand h tl)
+        in
+        Nfa.intersect nfa order_nfa |> Nfa.minimize |> Result.ok
+    in
+    Debug.dump_nfa ~msg:"NFA taking order into account: %s" Nfa.format_nfa nfa;
+    (nfa
+     |> Nfa.project (order |> List.map (fun str -> Map.find_exn s.vars str))
+     |> Nfa.run
+     && proof_order nfa order)
+    |> Result.ok)
+  |> first
+;;
+
+let%expect_test "Disproof 2**x equals to 0" =
+  Format.printf
+    "%b"
+    ({|2**x = 0|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
+;;
+
+let%expect_test "Proof 2**x equals to 1 if x = 0" =
+  Format.printf
+    "%b"
+    ({|2**x = 1|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Disproof 2**x + 2**y could be less than 2" =
+  Format.printf
+    "%b"
+    ({|2**x + 2**y < 2|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
+;;
+
+let%expect_test "Proof 2**x + 2**y could be less than 3" =
+  Format.printf
+    "%b"
+    ({|2**x + 2**y < 3|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Proof 2**x equals to 2**x" =
+  Format.printf
+    "%b"
+    ({|2**x = 2**x|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Proof 2**x equals to 2**y" =
+  Format.printf
+    "%b"
+    ({|2**x = 2**y|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Disproof 2**x equals to x" =
+  Format.printf
+    "%b"
+    ({|2**x = x|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
+;;
+
+let%expect_test "Proof 2**x equals to x + 1 with x = 1" =
+  Format.printf
+    "%b"
+    ({|2**x = x + 1|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Proof 2**x equals to x + 2 with x = 2" =
+  Format.printf
+    "%b"
+    ({|2**x = x + 2|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Disproof 2**x equals to x + 3" =
+  Format.printf
+    "%b"
+    ({|2**x = x + 3|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
+;;
+
+let%expect_test "Proof 2**x can be equal to 2**y + 1" =
+  Format.printf
+    "%b"
+    ({|2**x = 2**y + 1|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Proof 2**x can be equal to 2**y + 2" =
+  Format.printf
+    "%b"
+    ({|2**x = 2**y + 2|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Disproof 2**x can be equal to 2**y + 5" =
+  Format.printf
+    "%b"
+    ({|2**x = 2**y + 5|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
+;;
+
+let%expect_test "Proof 2**x can be equal to 2**y + 2**z + 7" =
+  Format.printf
+    "%b"
+    ({|2**x = 2**y + 2**z + 7|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Disproof 2**x <= y & y < (2(2**x)) & 2**z <= 5y & 5y < (2(2**z)) & x = z"
+  =
+  Format.printf
+    "%b"
+    ({|2**x <= y & y < (2(2**x)) & 2**z <= 5y & 5y < (2(2**z)) & x = z|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
+;;
+
+let%expect_test "Proof 2**x <= z & z < 2(2**x) & 60 <= z & z <= 100 & ~x = 6 & 5y = z" =
+  Format.printf
+    "%b"
+    ({|2**x <= z & z < 2(2**x) & 60 <= z & z <= 100 & ~x = 6 & 5y = z|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| true |}]
+;;
+
+let%expect_test "Disproof 2**x <= z & z < 2(2**x) & 61 <= z & z <= 100 & ~x = 6 & 5y = z" =
+  Format.printf
+    "%b"
+    ({|2**x <= z & z < 2(2**x) & 61 <= z & z <= 100 & ~x = 6 & 5y = z|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof_semenov
+     |> Result.get_ok);
+  [%expect {| false |}]
 ;;


### PR DESCRIPTION
This patch adds basic support for existential Semёnov arithmetic [^1].
Basically it's an existential theory of `<N, 2**x, +, =>` making it
possible to make proof some statements about strings and their length.

It can be accessed using `evalsemenov` command. It's followed by an
unquantified Semёnov arithmetic formula. Powers are expressed using
`2**x`. Currently only variables are allowed as the exponent. The
solver tries to find a model satisfying the formula.

Example.
```
> evalsemenov 2**x = x + 2
  Result: true

> evalsemenov 2**x = x + 3
  Result: false
```

[^1] https://arxiv.org/abs/2306.14593
