### PR TITLE
solver: add support for predicates

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,5 @@
 profile = ocamlformat
-version = 0.26.2
+version = 0.27.0
 sequence-style = terminator
 match-indent = 2
 match-indent-nested = always

--- a/MacadamiaSolver.opam
+++ b/MacadamiaSolver.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.16"}
   "angstrom"
   "bitv"
-  "ocamlformat" {= "0.26.2" & dev}
+  "ocamlformat" {= "0.27.0" & dev}
   "odoc" {with-doc}
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -206,8 +206,8 @@ let fold ff ft acc f =
         ff (foldf acc f1) f
     | (Exists (_, f1) | Any (_, f1)) as f ->
         ff (foldf acc f1) f
-    | Pred (_, _) as f ->
-        ff acc f
+    | Pred (_, args) as f ->
+        ff (List.fold_left foldt acc args) f
   in
   foldf acc f
 

--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -144,20 +144,8 @@ let length nfa = Array.length nfa.transitions
 
 let states nfa = 0 -- (length nfa - 1) |> Set.of_list
 
-let reverse_transitions transitions =
-  let reversed_transitions = Array.make (Array.length transitions) [] in
-  Array.iteri
-    (fun q delta ->
-      List.iter
-        (fun (label, q') ->
-          reversed_transitions.(q') <- (label, q) :: reversed_transitions.(q')
-          )
-        delta )
-    transitions;
-  reversed_transitions
-
 let remove_unreachable nfa =
-  let reversed_transitions = nfa.transitions |> reverse_transitions in
+  let reversed_transitions = nfa.transitions |> Graph.reverse in
   let reachable =
     let visited = Array.make (length nfa) false in
     let rec bfs reachable = function

--- a/lib/nfa.mli
+++ b/lib/nfa.mli
@@ -24,8 +24,6 @@ val create_dfa :
   -> deg:int
   -> t
 
-val map_labels : (int -> int) -> t -> t
-
 val run : t -> bool
 
 val intersect : t -> t -> t
@@ -37,6 +35,8 @@ val project : int list -> t -> t
 val truncate : int -> t -> t
 
 val is_graph : t -> bool
+
+val reenumerate : (int, int) Map.t -> t -> t
 
 val minimize : t -> t
 


### PR DESCRIPTION
This is a set of three patches for supporting predicates back again.

The first patch fixes the call that removes unreachable states in the NFA.
The problem has happened due to the wrong ordering of the index/value in
a few `mapi` calls.

The second patch makes NFA reverse reuse a graph reversing method. It's
possible since the automaton is an edge-labeled-graph equipped with
starting and final states.

The third patch adds support for predicates that's been reverted in fda25233
('nfa: drastically speed-up basic operations') due to migration to
bitvectors for representing edge labels. The implementation is similar
to the previous. The bitvectors are re-enumerated correspondingly to the
variable names.

Predicates can be used as follows.
```
> let even x = Ey x = 2y

> eval even(2)
Result: true

> eval Ax even(x) -> ~even(x + 1)
Result: true
```
