### PR TITLE
Generate AST ADTs constructors using deriving

### DIFF
--- a/MacadamiaSolver.opam
+++ b/MacadamiaSolver.opam
@@ -12,10 +12,12 @@ depends: [
   "dune" {>= "3.16"}
   "angstrom"
   "bitv"
-  "ocamlformat" {= "0.27.0" & dev}
-  "odoc" {with-doc}
+  "ppx_deriving"
+  "ppx_variants_conv"
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}
+  "ocamlformat" {dev}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -17,14 +17,15 @@
  (name MacadamiaSolver)
  (synopsis "Theorem Solver")
  (depends 
-   ocaml 
-   dune 
-   angstrom 
-   bitv 
-   (ocamlformat
-    (and
-     (= 0.26.2)
-     :dev)))
+  ocaml
+  dune
+  angstrom
+  bitv
+  ppx_deriving
+  ppx_variants_conv
+  (ppx_expect :with-test)
+  (ppx_inline_test :with-test)
+  (ocamlformat :dev))
  (tags
   (solver theorem)))
 

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -12,6 +12,7 @@ type term =
   | Add of term * term
   | Mul of int * term
   | Pow of int * term
+[@@deriving variants]
 
 type formula =
   | True
@@ -30,6 +31,7 @@ type formula =
   | Miff of formula * formula
   | Exists of varname list * formula
   | Any of varname list * formula
+[@@deriving variants]
 
 type stmt =
   | Def of string * varname list * formula
@@ -39,62 +41,7 @@ type stmt =
   | Parse of formula
   | List
   | Help
-
-let var x = Var x
-
-let const x = Const x
-
-let add x y = Add (x, y)
-
-let mul x y = Mul (x, y)
-
-let pow x y = Pow (x, y)
-
-let pred n p = Pred (n, p)
-
-let mtrue () = True
-
-let mfalse () = False
-
-let eq x y = Eq (x, y)
-
-let neq x y = Neq (x, y)
-
-let lt x y = Lt (x, y)
-
-let gt x y = Gt (x, y)
-
-let leq x y = Leq (x, y)
-
-let geq x y = Geq (x, y)
-
-let mnot x = Mnot x
-
-let mand x y = Mand (x, y)
-
-let mor x y = Mor (x, y)
-
-let mimpl x y = Mimpl (x, y)
-
-let miff x y = Miff (x, y)
-
-let exists x y = Exists (x, y)
-
-let any x y = Any (x, y)
-
-let def x p f = Def (x, p, f)
-
-let eval f = Eval f
-
-let eval_semenov f = EvalSemenov f
-
-let dump f = Dump f
-
-let parse f = Parse f
-
-let list () = List
-
-let help () = Help
+[@@deriving variants]
 
 let rec pp_term ppf = function
   | Var n ->

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -12,6 +12,7 @@ type term =
   | Add of term * term
   | Mul of int * term
   | Pow of int * term
+[@@deriving variants]
 
 type formula =
   | True
@@ -30,6 +31,7 @@ type formula =
   | Miff of formula * formula
   | Exists of varname list * formula
   | Any of varname list * formula
+[@@deriving variants]
 
 type stmt =
   | Def of string * varname list * formula
@@ -39,62 +41,7 @@ type stmt =
   | Parse of formula
   | List
   | Help
-
-val var : varname -> term
-
-val const : int -> term
-
-val add : term -> term -> term
-
-val mul : int -> term -> term
-
-val pow : int -> term -> term
-
-val pred : predname -> term list -> formula
-
-val mtrue : unit -> formula
-
-val mfalse : unit -> formula
-
-val eq : term -> term -> formula
-
-val neq : term -> term -> formula
-
-val lt : term -> term -> formula
-
-val gt : term -> term -> formula
-
-val leq : term -> term -> formula
-
-val geq : term -> term -> formula
-
-val mnot : formula -> formula
-
-val mand : formula -> formula -> formula
-
-val mor : formula -> formula -> formula
-
-val mimpl : formula -> formula -> formula
-
-val miff : formula -> formula -> formula
-
-val exists : varname list -> formula -> formula
-
-val any : varname list -> formula -> formula
-
-val def : string -> varname list -> formula -> stmt
-
-val eval : formula -> stmt
-
-val eval_semenov : formula -> stmt
-
-val dump : formula -> stmt
-
-val parse : formula -> stmt
-
-val list : unit -> stmt
-
-val help : unit -> stmt
+[@@deriving variants]
 
 val pp_term : Format.formatter -> term -> unit
 

--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,4 @@
  (libraries base angstrom bitv)
  (inline_tests)
  (preprocess
-  (pps ppx_inline_test ppx_assert ppx_expect)))
+  (pps ppx_variants_conv ppx_inline_test ppx_assert ppx_expect)))

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -116,15 +116,13 @@ let def =
 
 let stmt =
   kw1 "eval" Ast.eval formula
-  <|> kw1 "evalsemenov" Ast.eval_semenov formula
+  <|> kw1 "evalsemenov" Ast.evalsemenov formula
   <|> kw3 "let" Ast.def (ident <* whitespace)
         (many (whitespace *> ident))
         (whitespace *> char '=' *> whitespace *> formula)
   <|> kw1 "dump" Ast.dump formula
   <|> kw1 "parse" Ast.parse formula
-  <|> kw "list" (Ast.list ())
-  <|> kw "help" (Ast.help ())
-  <?> "Unknown statement"
+  <|> kw "list" Ast.list <|> kw "help" Ast.help <?> "Unknown statement"
 
 let parse_formula str = parse_string ~consume:Prefix formula str
 


### PR DESCRIPTION
This patch makes AST ADTs use ppx_variants_conv [^1] library for generating the constructors instead of writing boilerplate code.

[^1] https://github.com/janestreet/ppx_variants_conv