### PR TITLE
Switch to JaneStret formatting style

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
-profile = ocamlformat
+profile = janestreet
 version = 0.27.0
-sequence-style = terminator
 match-indent = 2
 match-indent-nested = always

--- a/bin/mandms.ml
+++ b/bin/mandms.ml
@@ -5,54 +5,51 @@
 open Lib
 
 let exec line = function
-  | Ast.Eval f -> (
-      let res = Solver.proof f in
-      match res with
-        | Ok res ->
-            Format.printf "Result: %b\n\n%!" res
-        | Error msg ->
-            Format.printf "Error: %s\n\n%!" msg )
-  | Ast.EvalSemenov _f ->
-      Format.printf "Semenov arithmetic is not yet supported\n\n%!"
-  | Ast.Dump f -> (
-    match Solver.dump f with
-      | Ok s ->
-          let dot_file = Format.sprintf "dumps/\"%s.dot\"" line in
-          let svg_file = Format.sprintf "dumps/\"%s.svg\"" line in
-          let oc = open_out (Format.sprintf "dumps/%s.dot" line) in
-          let command =
-            Format.sprintf "mkdir -p dumps/; dot -Tsvg %s > %s; xdg-open %s"
-              dot_file svg_file svg_file
-          in
-          Printf.fprintf oc "%s" s;
-          close_out oc;
-          Sys.command command |> ignore
-      | Error msg ->
-          Format.printf "Error: %s\n\n%!" msg )
-  | Ast.Def (name, params, formula) -> (
-    match Solver.pred name params formula with
-      | Ok () ->
-          ()
-      | Error msg ->
-          Format.printf "Error: %s\n\n%!" msg )
+  | Ast.Eval f ->
+    let res = Solver.proof f in
+    (match res with
+     | Ok res -> Format.printf "Result: %b\n\n%!" res
+     | Error msg -> Format.printf "Error: %s\n\n%!" msg)
+  | Ast.EvalSemenov _f -> Format.printf "Semenov arithmetic is not yet supported\n\n%!"
+  | Ast.Dump f ->
+    (match Solver.dump f with
+     | Ok s ->
+       let dot_file = Format.sprintf "dumps/\"%s.dot\"" line in
+       let svg_file = Format.sprintf "dumps/\"%s.svg\"" line in
+       let oc = open_out (Format.sprintf "dumps/%s.dot" line) in
+       let command =
+         Format.sprintf
+           "mkdir -p dumps/; dot -Tsvg %s > %s; xdg-open %s"
+           dot_file
+           svg_file
+           svg_file
+       in
+       Printf.fprintf oc "%s" s;
+       close_out oc;
+       Sys.command command |> ignore
+     | Error msg -> Format.printf "Error: %s\n\n%!" msg)
+  | Ast.Def (name, params, formula) ->
+    (match Solver.pred name params formula with
+     | Ok () -> ()
+     | Error msg -> Format.printf "Error: %s\n\n%!" msg)
   | Ast.Parse f ->
-      Format.printf "Formula AST: %a\n%!" Ast.pp_formula f;
-      Format.printf "Optimized AST: %a\n\n%!" Ast.pp_formula
-        (f |> Optimizer.optimize)
-  | Ast.List ->
-      Solver.list ()
-  | Ast.Help ->
-      ()
+    Format.printf "Formula AST: %a\n%!" Ast.pp_formula f;
+    Format.printf "Optimized AST: %a\n\n%!" Ast.pp_formula (f |> Optimizer.optimize)
+  | Ast.List -> Solver.list ()
+  | Ast.Help -> ()
+;;
 
 let () =
   let rec aux () =
     let line = read_line () in
     let stmt = Parser.parse line in
     match stmt with
-      | Ok stmt ->
-          exec line stmt; aux ()
-      | Error msg ->
-          Format.printf "Error: %s\n\n%!" msg;
-          aux ()
+    | Ok stmt ->
+      exec line stmt;
+      aux ()
+    | Error msg ->
+      Format.printf "Error: %s\n\n%!" msg;
+      aux ()
   in
   aux ()
+;;

--- a/dune-project
+++ b/dune-project
@@ -16,7 +16,7 @@
 (package
  (name MacadamiaSolver)
  (synopsis "Theorem Solver")
- (depends 
+ (depends
   ocaml
   dune
   angstrom

--- a/lib/NfaCollection.ml
+++ b/lib/NfaCollection.ml
@@ -5,22 +5,29 @@ type varpos = int
 let add ~lhs ~rhs ~sum =
   Nfa.create_nfa
     ~transitions:
-      [ (0, 0b000, 0)
-      ; (0, 0b101, 0)
-      ; (0, 0b110, 0)
-      ; (0, 0b011, 1)
-      ; (1, 0b111, 1)
-      ; (1, 0b010, 1)
-      ; (1, 0b001, 1)
-      ; (1, 0b100, 0) ]
-    ~start:[0] ~final:[0] ~vars:[sum; rhs; lhs]
+      [ 0, 0b000, 0
+      ; 0, 0b101, 0
+      ; 0, 0b110, 0
+      ; 0, 0b011, 1
+      ; 1, 0b111, 1
+      ; 1, 0b010, 1
+      ; 1, 0b001, 1
+      ; 1, 0b100, 0
+      ]
+    ~start:[ 0 ]
+    ~final:[ 0 ]
+    ~vars:[ sum; rhs; lhs ]
     ~deg:((max lhs rhs |> max sum) + 1)
+;;
 
 let eq lhs rhs =
   Nfa.create_nfa
-    ~transitions:[(0, 0b00, 0); (0, 0b11, 0)]
-    ~start:[0] ~final:[0] ~vars:[lhs; rhs]
+    ~transitions:[ 0, 0b00, 0; 0, 0b11, 0 ]
+    ~start:[ 0 ]
+    ~final:[ 0 ]
+    ~vars:[ lhs; rhs ]
     ~deg:(max lhs rhs + 1)
+;;
 
 let eq_const var (n : int) =
   let vec = Bitv.of_int_us n |> Bitv.to_list |> Bitv.of_list in
@@ -29,54 +36,63 @@ let eq_const var (n : int) =
     Bitv.foldi_right
       (fun i bit acc -> (i, (if bit then 1 else 0), i + 1) :: acc)
       vec
-      [(max, 0, max)]
+      [ max, 0, max ]
   in
-  Nfa.create_nfa ~start:[0] ~final:[max] ~transitions ~vars:[var] ~deg:(var + 1)
+  Nfa.create_nfa ~start:[ 0 ] ~final:[ max ] ~transitions ~vars:[ var ] ~deg:(var + 1)
+;;
 
 let n () =
-  Nfa.create_nfa ~transitions:[(0, 0, 0)] ~start:[0] ~final:[0] ~vars:[] ~deg:1
+  Nfa.create_nfa ~transitions:[ 0, 0, 0 ] ~start:[ 0 ] ~final:[ 0 ] ~vars:[] ~deg:1
+;;
 
-let z () = Nfa.create_nfa ~transitions:[] ~start:[0] ~final:[] ~vars:[] ~deg:1
+let z () = Nfa.create_nfa ~transitions:[] ~start:[ 0 ] ~final:[] ~vars:[] ~deg:1
 
 let leq lhs rhs =
   Nfa.create_nfa
     ~transitions:
-      [ (0, 0b00, 0)
-      ; (0, 0b11, 0)
-      ; (0, 0b10, 0)
-      ; (0, 0b01, 1)
-      ; (1, 0b11, 1)
-      ; (1, 0b00, 1)
-      ; (1, 0b01, 1)
-      ; (1, 0b10, 0) ]
-    ~start:[0] ~final:[0] ~vars:[rhs; lhs]
+      [ 0, 0b00, 0
+      ; 0, 0b11, 0
+      ; 0, 0b10, 0
+      ; 0, 0b01, 1
+      ; 1, 0b11, 1
+      ; 1, 0b00, 1
+      ; 1, 0b01, 1
+      ; 1, 0b10, 0
+      ]
+    ~start:[ 0 ]
+    ~final:[ 0 ]
+    ~vars:[ rhs; lhs ]
     ~deg:(max lhs rhs + 1)
+;;
 
 let geq x y = leq y x
 
 let lt lhs rhs =
   Nfa.create_nfa
     ~transitions:
-      [ (0, 0b01, 1)
-      ; (0, 0b11, 0)
-      ; (0, 0b10, 0)
-      ; (0, 0b00, 0)
-      ; (1, 0b11, 1)
-      ; (1, 0b01, 1)
-      ; (1, 0b00, 1)
-      ; (1, 0b10, 0) ]
-    ~start:[0] ~final:[1] ~vars:[lhs; rhs]
+      [ 0, 0b01, 1
+      ; 0, 0b11, 0
+      ; 0, 0b10, 0
+      ; 0, 0b00, 0
+      ; 1, 0b11, 1
+      ; 1, 0b01, 1
+      ; 1, 0b00, 1
+      ; 1, 0b10, 0
+      ]
+    ~start:[ 0 ]
+    ~final:[ 1 ]
+    ~vars:[ lhs; rhs ]
     ~deg:(max lhs rhs + 1)
+;;
 
 let gt x y = lt y x
 
 let torename var a c =
-  let trans1 =
-    List.init (a + c - 1) Fun.id |> List.map (fun x -> (x, 0b0, x + 1))
-  in
+  let trans1 = List.init (a + c - 1) Fun.id |> List.map (fun x -> x, 0b0, x + 1) in
   Nfa.create_nfa
-    ~transitions:
-      ([(a + c - 1, 0b0, a); (a, 0b1, a + c); (a + c, 0b0, a + c)] @ trans1)
-    ~start:[0]
-    ~final:[a + c]
-    ~vars:[var] ~deg:(var + 1)
+    ~transitions:([ a + c - 1, 0b0, a; a, 0b1, a + c; a + c, 0b0, a + c ] @ trans1)
+    ~start:[ 0 ]
+    ~final:[ a + c ]
+    ~vars:[ var ]
+    ~deg:(var + 1)
+;;

--- a/lib/NfaCollection.mli
+++ b/lib/NfaCollection.mli
@@ -1,21 +1,12 @@
 type varpos = int
 
 val add : lhs:varpos -> rhs:varpos -> sum:varpos -> Nfa.t
-
 val eq : varpos -> varpos -> Nfa.t
-
 val eq_const : varpos -> int -> Nfa.t
-
 val n : unit -> Nfa.t
-
 val z : unit -> Nfa.t
-
 val leq : varpos -> varpos -> Nfa.t
-
 val geq : varpos -> varpos -> Nfa.t
-
 val lt : varpos -> varpos -> Nfa.t
-
 val gt : varpos -> varpos -> Nfa.t
-
 val torename : varpos -> int -> int -> Nfa.t

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -3,7 +3,6 @@
 (** SPDX-License-Identifier: MIT *)
 
 type varname = string
-
 type predname = string
 
 type term =
@@ -44,173 +43,127 @@ type stmt =
 [@@deriving variants]
 
 let rec pp_term ppf = function
-  | Var n ->
-      Format.fprintf ppf "%s" n
-  | Const n ->
-      Format.fprintf ppf "%d" n
-  | Add (a, b) ->
-      Format.fprintf ppf "(%a + %a)" pp_term a pp_term b
-  | Mul (a, b) ->
-      Format.fprintf ppf "(%d * %a)" a pp_term b
-  | Pow (a, b) ->
-      Format.fprintf ppf "(%d ** %a)" a pp_term b
+  | Var n -> Format.fprintf ppf "%s" n
+  | Const n -> Format.fprintf ppf "%d" n
+  | Add (a, b) -> Format.fprintf ppf "(%a + %a)" pp_term a pp_term b
+  | Mul (a, b) -> Format.fprintf ppf "(%d * %a)" a pp_term b
+  | Pow (a, b) -> Format.fprintf ppf "(%d ** %a)" a pp_term b
+;;
 
 let rec pp_formula ppf = function
-  | True ->
-      Format.fprintf ppf "True"
-  | False ->
-      Format.fprintf ppf "False"
-  | Pred (a, b) ->
-      Format.fprintf ppf "(P %s %a)" a (Format.pp_print_list pp_term) b
-  | Eq (a, b) ->
-      Format.fprintf ppf "(%a = %a)" pp_term a pp_term b
-  | Neq (a, b) ->
-      Format.fprintf ppf "(%a != %a)" pp_term a pp_term b
-  | Lt (a, b) ->
-      Format.fprintf ppf "(%a < %a)" pp_term a pp_term b
-  | Gt (a, b) ->
-      Format.fprintf ppf "(%a > %a)" pp_term a pp_term b
-  | Leq (a, b) ->
-      Format.fprintf ppf "(%a <= %a)" pp_term a pp_term b
-  | Geq (a, b) ->
-      Format.fprintf ppf "(%a >= %a)" pp_term a pp_term b
-  | Mnot a ->
-      Format.fprintf ppf "(~ %a)" pp_formula a
-  | Mand (a, b) ->
-      Format.fprintf ppf "(%a & %a)" pp_formula a pp_formula b
-  | Mor (a, b) ->
-      Format.fprintf ppf "(%a | %a)" pp_formula a pp_formula b
-  | Mimpl (a, b) ->
-      Format.fprintf ppf "(%a -> %a)" pp_formula a pp_formula b
-  | Miff (a, b) ->
-      Format.fprintf ppf "(%a <-> %a)" pp_formula a pp_formula b
+  | True -> Format.fprintf ppf "True"
+  | False -> Format.fprintf ppf "False"
+  | Pred (a, b) -> Format.fprintf ppf "(P %s %a)" a (Format.pp_print_list pp_term) b
+  | Eq (a, b) -> Format.fprintf ppf "(%a = %a)" pp_term a pp_term b
+  | Neq (a, b) -> Format.fprintf ppf "(%a != %a)" pp_term a pp_term b
+  | Lt (a, b) -> Format.fprintf ppf "(%a < %a)" pp_term a pp_term b
+  | Gt (a, b) -> Format.fprintf ppf "(%a > %a)" pp_term a pp_term b
+  | Leq (a, b) -> Format.fprintf ppf "(%a <= %a)" pp_term a pp_term b
+  | Geq (a, b) -> Format.fprintf ppf "(%a >= %a)" pp_term a pp_term b
+  | Mnot a -> Format.fprintf ppf "(~ %a)" pp_formula a
+  | Mand (a, b) -> Format.fprintf ppf "(%a & %a)" pp_formula a pp_formula b
+  | Mor (a, b) -> Format.fprintf ppf "(%a | %a)" pp_formula a pp_formula b
+  | Mimpl (a, b) -> Format.fprintf ppf "(%a -> %a)" pp_formula a pp_formula b
+  | Miff (a, b) -> Format.fprintf ppf "(%a <-> %a)" pp_formula a pp_formula b
   | Exists (a, b) ->
-      Format.fprintf ppf "(E%a %a)"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.fprintf ppf " ")
-           Format.pp_print_string )
-        a pp_formula b
+    Format.fprintf
+      ppf
+      "(E%a %a)"
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.fprintf ppf " ")
+         Format.pp_print_string)
+      a
+      pp_formula
+      b
   | Any (a, b) ->
-      Format.fprintf ppf "(A%a %a)"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.fprintf ppf " ")
-           Format.pp_print_string )
-        a pp_formula b
+    Format.fprintf
+      ppf
+      "(A%a %a)"
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.fprintf ppf " ")
+         Format.pp_print_string)
+      a
+      pp_formula
+      b
+;;
 
 let quantifier_ast_exn = function
-  | Exists _ ->
-      exists
-  | Any _ ->
-      any
-  | _ ->
-      assert false
+  | Exists _ -> exists
+  | Any _ -> any
+  | _ -> assert false
+;;
 
 let binconj_ast_exn = function
-  | Mand _ ->
-      mand
-  | Mor _ ->
-      mor
-  | Mimpl _ ->
-      mimpl
-  | Miff _ ->
-      miff
-  | _ ->
-      assert false
+  | Mand _ -> mand
+  | Mor _ -> mor
+  | Mimpl _ -> mimpl
+  | Miff _ -> miff
+  | _ -> assert false
+;;
 
 let tfold ft acc t =
   let rec foldt acc = function
-    | (Const _ | Var _) as f ->
-        ft acc f
-    | (Pow (_, t1) | Mul (_, t1)) as t ->
-        ft (foldt acc t1) t
-    | Add (t1, t2) as t ->
-        ft (foldt (foldt acc t1) t2) t
+    | (Const _ | Var _) as f -> ft acc f
+    | (Pow (_, t1) | Mul (_, t1)) as t -> ft (foldt acc t1) t
+    | Add (t1, t2) as t -> ft (foldt (foldt acc t1) t2) t
   in
   foldt acc t
+;;
 
 let fold ff ft acc f =
   let rec foldt acc = function
-    | (Const _ | Var _) as f ->
-        ft acc f
-    | (Pow (_, t1) | Mul (_, t1)) as t ->
-        ft (foldt acc t1) t
-    | Add (t1, t2) as t ->
-        ft (foldt (foldt acc t1) t2) t
+    | (Const _ | Var _) as f -> ft acc f
+    | (Pow (_, t1) | Mul (_, t1)) as t -> ft (foldt acc t1) t
+    | Add (t1, t2) as t -> ft (foldt (foldt acc t1) t2) t
   in
   let rec foldf acc = function
-    | (True | False) as f ->
-        ff acc f
+    | (True | False) as f -> ff acc f
     | ( Eq (t1, t2)
       | Lt (t1, t2)
       | Gt (t1, t2)
       | Leq (t1, t2)
       | Geq (t1, t2)
-      | Neq (t1, t2) ) as f ->
-        ff (foldt (foldt acc t1) t2) f
+      | Neq (t1, t2) ) as f -> ff (foldt (foldt acc t1) t2) f
     | (Mor (f1, f2) | Mand (f1, f2) | Miff (f1, f2) | Mimpl (f1, f2)) as f ->
-        ff (foldf (foldf acc f1) f2) f
-    | Mnot f1 as f ->
-        ff (foldf acc f1) f
-    | (Exists (_, f1) | Any (_, f1)) as f ->
-        ff (foldf acc f1) f
-    | Pred (_, args) as f ->
-        ff (List.fold_left foldt acc args) f
+      ff (foldf (foldf acc f1) f2) f
+    | Mnot f1 as f -> ff (foldf acc f1) f
+    | (Exists (_, f1) | Any (_, f1)) as f -> ff (foldf acc f1) f
+    | Pred (_, args) as f -> ff (List.fold_left foldt acc args) f
   in
   foldf acc f
+;;
 
 let for_some ff ft f =
-  fold
-    (fun acc f -> ff f |> ( || ) acc)
-    (fun acc t -> ft t |> ( || ) acc)
-    false f
+  fold (fun acc f -> ff f |> ( || ) acc) (fun acc t -> ft t |> ( || ) acc) false f
+;;
 
 let for_all ff ft f =
-  fold
-    (fun acc f -> ff f |> ( && ) acc)
-    (fun acc t -> ft t |> ( && ) acc)
-    true f
+  fold (fun acc f -> ff f |> ( && ) acc) (fun acc t -> ft t |> ( && ) acc) true f
+;;
 
 let map ff ft f =
   let rec mapt = function
-    | (Const _ | Var _) as f ->
-        ft f
-    | Mul (a, t1) ->
-        Mul (a, mapt t1) |> ft
-    | Add (t1, t2) ->
-        Add (mapt t1, mapt t2) |> ft
-    | Pow (a, t1) ->
-        Pow (a, mapt t1) |> ft
+    | (Const _ | Var _) as f -> ft f
+    | Mul (a, t1) -> Mul (a, mapt t1) |> ft
+    | Add (t1, t2) -> Add (mapt t1, mapt t2) |> ft
+    | Pow (a, t1) -> Pow (a, mapt t1) |> ft
   in
   let rec mapf = function
-    | (True | False) as f ->
-        f |> ff
-    | Eq (t1, t2) ->
-        Eq (mapt t1, mapt t2) |> ff
-    | Lt (t1, t2) ->
-        Lt (mapt t1, mapt t2) |> ff
-    | Gt (t1, t2) ->
-        Gt (mapt t1, mapt t2) |> ff
-    | Leq (t1, t2) ->
-        Leq (mapt t1, mapt t2) |> ff
-    | Geq (t1, t2) ->
-        Geq (mapt t1, mapt t2) |> ff
-    | Neq (t1, t2) ->
-        Neq (mapt t1, mapt t2) |> ff
-    | Mor (f1, f2) ->
-        Mor (mapf f1, mapf f2) |> ff
-    | Mand (f1, f2) ->
-        Mand (mapf f1, mapf f2) |> ff
-    | Miff (f1, f2) ->
-        Miff (mapf f1, mapf f2) |> ff
-    | Mimpl (f1, f2) ->
-        Mimpl (mapf f1, mapf f2) |> ff
-    | Mnot f1 ->
-        Mnot (mapf f1) |> ff
-    | Exists (a, f1) ->
-        Exists (a, mapf f1) |> ff
-    | Any (a, f1) ->
-        Any (a, mapf f1) |> ff
-    | Pred (_, _) as f ->
-        f |> ff
+    | (True | False) as f -> f |> ff
+    | Eq (t1, t2) -> Eq (mapt t1, mapt t2) |> ff
+    | Lt (t1, t2) -> Lt (mapt t1, mapt t2) |> ff
+    | Gt (t1, t2) -> Gt (mapt t1, mapt t2) |> ff
+    | Leq (t1, t2) -> Leq (mapt t1, mapt t2) |> ff
+    | Geq (t1, t2) -> Geq (mapt t1, mapt t2) |> ff
+    | Neq (t1, t2) -> Neq (mapt t1, mapt t2) |> ff
+    | Mor (f1, f2) -> Mor (mapf f1, mapf f2) |> ff
+    | Mand (f1, f2) -> Mand (mapf f1, mapf f2) |> ff
+    | Miff (f1, f2) -> Miff (mapf f1, mapf f2) |> ff
+    | Mimpl (f1, f2) -> Mimpl (mapf f1, mapf f2) |> ff
+    | Mnot f1 -> Mnot (mapf f1) |> ff
+    | Exists (a, f1) -> Exists (a, mapf f1) |> ff
+    | Any (a, f1) -> Any (a, mapf f1) |> ff
+    | Pred (_, _) as f -> f |> ff
   in
   mapf f
+;;

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -3,7 +3,6 @@
 (* SPDX-License-Identifier: MIT *)
 
 type varname = string
-
 type predname = string
 
 type term =
@@ -44,20 +43,11 @@ type stmt =
 [@@deriving variants]
 
 val pp_term : Format.formatter -> term -> unit
-
 val pp_formula : Format.formatter -> formula -> unit
-
 val quantifier_ast_exn : formula -> varname list -> formula -> formula
-
 val binconj_ast_exn : formula -> formula -> formula -> formula
-
 val tfold : ('acc -> term -> 'acc) -> 'acc -> term -> 'acc
-
-val fold :
-  ('acc -> formula -> 'acc) -> ('acc -> term -> 'acc) -> 'acc -> formula -> 'acc
-
+val fold : ('acc -> formula -> 'acc) -> ('acc -> term -> 'acc) -> 'acc -> formula -> 'acc
 val for_some : (formula -> bool) -> (term -> bool) -> formula -> bool
-
 val for_all : (formula -> bool) -> (term -> bool) -> formula -> bool
-
 val map : (formula -> formula) -> (term -> term) -> formula -> formula

--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -4,50 +4,50 @@ module Map = Base.Map.Poly
 module Sequence = Base.Sequence
 
 type deg = int
-
 type state = int
 
 let ( let* ) = Option.bind
-
 let return = Option.some
 
 let ( -- ) i j =
   let rec aux n acc = if n < i then acc else aux (n - 1) (n :: acc) in
   aux j []
+;;
 
 let rec pow a = function
-  | 0 ->
-      1
-  | 1 ->
-      a
+  | 0 -> 1
+  | 1 -> a
   | n ->
-      let b = pow a (n / 2) in
-      b * b * if n mod 2 = 0 then 1 else a
+    let b = pow a (n / 2) in
+    b * b * if n mod 2 = 0 then 1 else a
+;;
 
 let stretch vec mask_list deg =
   let m =
     mask_list
-    |> List.mapi (fun i k -> (k, Set.singleton i))
+    |> List.mapi (fun i k -> k, Set.singleton i)
     |> Map.of_alist_reduce ~f:Set.union
   in
   let ok =
     0 -- deg
     |> List.for_all (fun j ->
-           let js = Map.find m j |> Option.value ~default:Set.empty in
-           Set.for_all ~f:(fun j -> Bitv.get vec j) js
-           || Set.for_all ~f:(fun j -> Bitv.get vec j |> not) js )
+      let js = Map.find m j |> Option.value ~default:Set.empty in
+      Set.for_all ~f:(fun j -> Bitv.get vec j) js
+      || Set.for_all ~f:(fun j -> Bitv.get vec j |> not) js)
   in
   match ok with
-    | true ->
-        Bitv.init deg (fun i ->
-            (let* js = Map.find m i in
-             let* j = Set.nth js 0 in
-             let v = Bitv.get vec j in
-             match v with true -> Option.some true | false -> Option.none )
-            |> Option.is_some )
-        |> return
-    | false ->
-        Option.none
+  | true ->
+    Bitv.init deg (fun i ->
+      (let* js = Map.find m i in
+       let* j = Set.nth js 0 in
+       let v = Bitv.get vec j in
+       match v with
+       | true -> Option.some true
+       | false -> Option.none)
+      |> Option.is_some)
+    |> return
+  | false -> Option.none
+;;
 
 module Label = struct
   type t = Bitv.t * Bitv.t
@@ -65,6 +65,7 @@ module Label = struct
     let mask2 = extend mask2 in
     let mask = Bitv.bw_and mask1 mask2 in
     Bitv.equal (Bitv.bw_and vec1 mask) (Bitv.bw_and vec2 mask)
+  ;;
 
   let combine (vec1, mask1) (vec2, mask2) =
     let len = max (Bitv.length mask1) (Bitv.length mask2) in
@@ -77,20 +78,19 @@ module Label = struct
     let vec2 = extend vec2 in
     let mask1 = extend mask1 in
     let mask2 = extend mask2 in
-    (Bitv.bw_or vec1 vec2, Bitv.bw_or mask1 mask2)
+    Bitv.bw_or vec1 vec2, Bitv.bw_or mask1 mask2
+  ;;
 
   let project proj (vec, mask) =
     let len = Bitv.length mask in
-    let proj =
-      Bitv.create len true |> Bitv.bw_xor (Bitv.of_list_with_length proj len)
-    in
-    (Bitv.bw_and vec proj, Bitv.bw_and mask proj)
+    let proj = Bitv.create len true |> Bitv.bw_xor (Bitv.of_list_with_length proj len) in
+    Bitv.bw_and vec proj, Bitv.bw_and mask proj
+  ;;
 
   let truncate len (vec, mask) =
-    ( Bitv.init len (fun i ->
-          if i < Bitv.length vec then Bitv.get vec i else false )
-    , Bitv.init len (fun i ->
-          if i < Bitv.length mask then Bitv.get mask i else false ) )
+    ( Bitv.init len (fun i -> if i < Bitv.length vec then Bitv.get vec i else false)
+    , Bitv.init len (fun i -> if i < Bitv.length mask then Bitv.get mask i else false) )
+  ;;
 
   let is_zero (vec, mask) = Bitv.bw_and vec mask |> Bitv.all_zeros
 
@@ -99,16 +99,21 @@ module Label = struct
     0 -- (pow 2 (List.length mask_list) - 1)
     |> List.map Bitv.of_int_us
     |> List.map (fun x -> stretch x mask_list (Bitv.length mask) |> Option.get)
-    |> List.map (fun x -> (x, mask))
+    |> List.map (fun x -> x, mask)
+  ;;
 
-  let z deg = (Bitv.init deg (fun _ -> false), Bitv.init deg (fun _ -> false))
+  let z deg = Bitv.init deg (fun _ -> false), Bitv.init deg (fun _ -> false)
 
   let pp_label ppf (vec, mask) =
     let vec = Bitv.L.to_string vec |> String.to_seq in
     let mask = Bitv.L.to_string mask |> String.to_seq in
     Seq.zip vec mask
-    |> Seq.map (function _, '0' -> '_' | x, _ -> x)
-    |> String.of_seq |> Format.fprintf ppf "(%s)"
+    |> Seq.map (function
+      | _, '0' -> '_'
+      | x, _ -> x)
+    |> String.of_seq
+    |> Format.fprintf ppf "(%s)"
+  ;;
 
   let reenumerate map (vec, mask) =
     let length =
@@ -116,13 +121,18 @@ module Label = struct
     in
     let vec =
       Bitv.init length (fun i ->
-          match Map.find map i with Some j -> Bitv.get vec j | None -> false )
+        match Map.find map i with
+        | Some j -> Bitv.get vec j
+        | None -> false)
     in
     let mask =
       Bitv.init length (fun i ->
-          match Map.find map i with Some j -> Bitv.get mask j | None -> false )
+        match Map.find map i with
+        | Some j -> Bitv.get mask j
+        | None -> false)
     in
-    (vec, mask)
+    vec, mask
+  ;;
   (*let deg (_, mask) = Bitv.length mask*)
 end
 
@@ -135,22 +145,23 @@ module Graph = struct
     let rev_graph = Array.make (verticies graph) [] in
     Array.iteri
       (fun q delta ->
-        List.iter
-          (fun (label, q') -> rev_graph.(q') <- (label, q) :: rev_graph.(q'))
-          delta )
+         List.iter
+           (fun (label, q') -> rev_graph.(q') <- (label, q) :: rev_graph.(q'))
+           delta)
       graph;
     rev_graph
+  ;;
 end
 
 type t =
-  { transitions: Graph.t
-  ; final: state Set.t
-  ; start: state Set.t
-  ; deg: deg
-  ; is_dfa: bool }
+  { transitions : Graph.t
+  ; final : state Set.t
+  ; start : state Set.t
+  ; deg : deg
+  ; is_dfa : bool
+  }
 
 let length nfa = Array.length nfa.transitions
-
 let states nfa = 0 -- (length nfa - 1) |> Set.of_list
 
 let remove_unreachable nfa =
@@ -158,129 +169,145 @@ let remove_unreachable nfa =
   let reachable =
     let visited = Array.make (length nfa) false in
     let rec bfs reachable = function
-      | [] ->
-          reachable
+      | [] -> reachable
       | q :: tl ->
-          if visited.(q) then reachable
-          else (
-            visited.(q) <- true;
-            let reachable = Set.add reachable q in
-            let delta = Array.get reversed_transitions q in
-            let qs = (delta |> List.map snd) @ tl in
-            bfs reachable qs )
+        if visited.(q)
+        then reachable
+        else (
+          visited.(q) <- true;
+          let reachable = Set.add reachable q in
+          let delta = Array.get reversed_transitions q in
+          let qs = (delta |> List.map snd) @ tl in
+          bfs reachable qs)
     in
     bfs Set.empty (nfa.final |> Set.to_list)
   in
   let map_new_old =
-    reachable |> Set.to_sequence
-    |> Sequence.mapi ~f:(fun i v -> (i, v))
+    reachable
+    |> Set.to_sequence
+    |> Sequence.mapi ~f:(fun i v -> i, v)
     |> Map.of_sequence_exn
   in
   let map_old_new =
-    reachable |> Set.to_sequence
-    |> Sequence.mapi ~f:(fun i v -> (v, i))
+    reachable
+    |> Set.to_sequence
+    |> Sequence.mapi ~f:(fun i v -> v, i)
     |> Map.of_sequence_exn
   in
   let start = nfa.start |> Set.filter_map ~f:(Map.find map_old_new) in
   let final = nfa.final |> Set.filter_map ~f:(Map.find map_old_new) in
   let transitions =
     Array.init (Set.length reachable) (fun q ->
-        let old_q = Map.find_exn map_new_old q in
-        let delta = nfa.transitions.(old_q) in
-        List.filter_map
-          (fun (label, old_q') ->
-            if Set.mem reachable old_q' then
-              let q' = Map.find_exn map_old_new old_q' in
-              Option.some (label, q')
-            else Option.none )
-          delta )
+      let old_q = Map.find_exn map_new_old q in
+      let delta = nfa.transitions.(old_q) in
+      List.filter_map
+        (fun (label, old_q') ->
+           if Set.mem reachable old_q'
+           then (
+             let q' = Map.find_exn map_old_new old_q' in
+             Option.some (label, q'))
+           else Option.none)
+        delta)
   in
-  {transitions; start; final; deg= nfa.deg; is_dfa= nfa.is_dfa}
+  { transitions; start; final; deg = nfa.deg; is_dfa = nfa.is_dfa }
+;;
 
 let update_final_states_nfa nfa =
   let reversed_transitions = nfa.transitions |> Graph.reverse in
   let final =
     let visited = Array.make (length nfa) false in
     let rec bfs reachable = function
-      | [] ->
-          reachable
+      | [] -> reachable
       | q :: tl ->
-          if visited.(q) then bfs reachable tl
-          else (
-            visited.(q) <- true;
-            let reachable = Set.add reachable q in
-            let delta =
-              Array.get reversed_transitions q
-              |> List.filter (fun (label, _) -> Label.is_zero label)
-            in
-            let qs = (delta |> List.map snd) @ tl in
-            bfs reachable qs )
+        if visited.(q)
+        then bfs reachable tl
+        else (
+          visited.(q) <- true;
+          let reachable = Set.add reachable q in
+          let delta =
+            Array.get reversed_transitions q
+            |> List.filter (fun (label, _) -> Label.is_zero label)
+          in
+          let qs = (delta |> List.map snd) @ tl in
+          bfs reachable qs)
     in
     bfs Set.empty (nfa.final |> Set.to_list)
   in
-  { transitions= nfa.transitions
-  ; start= nfa.start
+  { transitions = nfa.transitions
+  ; start = nfa.start
   ; final
-  ; deg= nfa.deg
-  ; is_dfa= nfa.is_dfa }
+  ; deg = nfa.deg
+  ; is_dfa = nfa.is_dfa
+  }
+;;
 
-let create_nfa ~(transitions : (state * int * state) list) ~(start : state list)
-    ~(final : state list) ~(vars : int list) ~(deg : int) =
+let create_nfa
+      ~(transitions : (state * int * state) list)
+      ~(start : state list)
+      ~(final : state list)
+      ~(vars : int list)
+      ~(deg : int)
+  =
   let vars = List.rev vars in
   let max =
-    transitions
-    |> List.map (fun (fst, _, snd) -> max fst snd)
-    |> List.fold_left max 0
+    transitions |> List.map (fun (fst, _, snd) -> max fst snd) |> List.fold_left max 0
   in
   let transitions =
     transitions
     |> List.fold_left
          (fun lists (src, lbl, dst) ->
-           lists.(src) <- (lbl, dst) :: lists.(src);
-           lists )
+            lists.(src) <- (lbl, dst) :: lists.(src);
+            lists)
          (Array.init (max + 1) (Fun.const []))
     |> Array.map (fun delta ->
-           List.filter_map
-             (fun (label, q') ->
-               let* vec = stretch (Bitv.of_int_us label) vars deg in
-               ((vec, Bitv.of_list_with_length vars deg), q') |> return )
-             delta )
+      List.filter_map
+        (fun (label, q') ->
+           let* vec = stretch (Bitv.of_int_us label) vars deg in
+           ((vec, Bitv.of_list_with_length vars deg), q') |> return)
+        delta)
   in
   { transitions
-  ; final= Set.of_list final
-  ; start= Set.of_list start
+  ; final = Set.of_list final
+  ; start = Set.of_list start
   ; deg
-  ; is_dfa= false }
+  ; is_dfa = false
+  }
   |> update_final_states_nfa
+;;
 
-let create_dfa ~(transitions : (state * int * state) list) ~(start : state)
-    ~(final : state list) ~(vars : int list) ~(deg : int) =
+let create_dfa
+      ~(transitions : (state * int * state) list)
+      ~(start : state)
+      ~(final : state list)
+      ~(vars : int list)
+      ~(deg : int)
+  =
   let vars = List.rev vars in
   let max =
-    transitions
-    |> List.map (fun (fst, _, snd) -> max fst snd)
-    |> List.fold_left max 0
+    transitions |> List.map (fun (fst, _, snd) -> max fst snd) |> List.fold_left max 0
   in
   (* TODO: ensure transitions are actually deterministic. *)
   let transitions =
     transitions
     |> List.fold_left
          (fun lists (src, lbl, dst) ->
-           lists.(src) <- (lbl, dst) :: lists.(src);
-           lists )
+            lists.(src) <- (lbl, dst) :: lists.(src);
+            lists)
          (Array.init (max + 1) (Fun.const []))
     |> Array.map (fun delta ->
-           List.filter_map
-             (fun (label, q') ->
-               let* vec = stretch (Bitv.of_int_us label) vars deg in
-               ((vec, Bitv.of_list_with_length vars deg), q') |> return )
-             delta )
+      List.filter_map
+        (fun (label, q') ->
+           let* vec = stretch (Bitv.of_int_us label) vars deg in
+           ((vec, Bitv.of_list_with_length vars deg), q') |> return)
+        delta)
   in
   { transitions
-  ; final= Set.of_list final
-  ; start= Set.singleton start
+  ; final = Set.of_list final
+  ; start = Set.singleton start
   ; deg
-  ; is_dfa= true }
+  ; is_dfa = true
+  }
+;;
 
 let run nfa = Set.are_disjoint nfa.start nfa.final |> not
 
@@ -288,58 +315,65 @@ let intersect nfa1 nfa2 =
   let cartesian_product l1 l2 =
     Set.fold
       ~f:(fun x a -> Set.fold ~f:(fun y b -> Set.add y (a, b)) ~init:x l2)
-      ~init:Set.empty l1
+      ~init:Set.empty
+      l1
   in
   let counter = ref 0 in
   let visited = Array.make_matrix (length nfa1) (length nfa2) (-1) in
   let q (q1, q2) = visited.(q1).(q2) in
   let is_visited (q1, q2) = q (q1, q2) <> -1 in
   let visit (q1, q2) =
-    if is_visited (q1, q2) |> not then (
+    if is_visited (q1, q2) |> not
+    then (
       visited.(q1).(q2) <- !counter;
-      counter := !counter + 1 )
+      counter := !counter + 1)
   in
   let rec aux transitions queue =
-    if Queue.is_empty queue then transitions
-    else
+    if Queue.is_empty queue
+    then transitions
+    else (
       let q1, q2 = Queue.pop queue in
       let delta1 = nfa1.transitions.(q1) in
       let delta2 = nfa2.transitions.(q2) in
       let delta =
         List.fold_left
           (fun acc_delta (label1, q1') ->
-            List.fold_left
-              (fun acc_delta (label2, q2') ->
-                let equal = Label.equal label1 label2 in
-                match equal with
+             List.fold_left
+               (fun acc_delta (label2, q2') ->
+                  let equal = Label.equal label1 label2 in
+                  match equal with
                   | true ->
-                      let label = Label.combine label1 label2 in
-                      let is_visited = is_visited (q1', q2') in
-                      visit (q1', q2');
-                      let q' = q (q1', q2') in
-                      let acc_delta = (label, q') :: acc_delta in
-                      if is_visited |> not then Queue.add (q1', q2') queue;
-                      acc_delta
-                  | false ->
-                      acc_delta )
-              acc_delta delta2 )
-          [] delta1
+                    let label = Label.combine label1 label2 in
+                    let is_visited = is_visited (q1', q2') in
+                    visit (q1', q2');
+                    let q' = q (q1', q2') in
+                    let acc_delta = (label, q') :: acc_delta in
+                    if is_visited |> not then Queue.add (q1', q2') queue;
+                    acc_delta
+                  | false -> acc_delta)
+               acc_delta
+               delta2)
+          []
+          delta1
       in
-      delta :: aux transitions queue
+      delta :: aux transitions queue)
   in
   let start_pairs = cartesian_product nfa1.start nfa2.start in
   let queue = Queue.create () in
-  Set.iter ~f:(fun x -> visit x; Queue.add x queue) start_pairs;
+  Set.iter
+    ~f:(fun x ->
+      visit x;
+      Queue.add x queue)
+    start_pairs;
   let transitions = aux [] queue |> Array.of_list in
   let start = start_pairs |> Set.map ~f:q in
   let final =
-    cartesian_product nfa1.final nfa2.final
-    |> Set.map ~f:q
-    |> Set.filter ~f:(( <> ) (-1))
+    cartesian_product nfa1.final nfa2.final |> Set.map ~f:q |> Set.filter ~f:(( <> ) (-1))
   in
   let deg = max nfa1.deg nfa2.deg in
   let is_dfa = nfa1.is_dfa && nfa2.is_dfa in
-  {final; start; transitions; deg; is_dfa}
+  { final; start; transitions; deg; is_dfa }
+;;
 
 let unite nfa1 nfa2 =
   let s1 q = q in
@@ -348,52 +382,56 @@ let unite nfa1 nfa2 =
   let final = Set.union (Set.map ~f:s1 nfa1.final) (Set.map ~f:s2 nfa2.final) in
   let transitions =
     Array.append
-      ( nfa1.transitions
-      |> Array.map (fun delta ->
-             List.map (fun (label, q') -> (label, s1 q')) delta ) )
-      ( nfa2.transitions
-      |> Array.map (fun delta ->
-             List.map (fun (label, q') -> (label, s2 q')) delta ) )
+      (nfa1.transitions
+       |> Array.map (fun delta -> List.map (fun (label, q') -> label, s1 q') delta))
+      (nfa2.transitions
+       |> Array.map (fun delta -> List.map (fun (label, q') -> label, s2 q') delta))
   in
   let deg = max nfa1.deg nfa2.deg in
-  {start; final; transitions; deg; is_dfa= false}
+  { start; final; transitions; deg; is_dfa = false }
+;;
 
 let is_graph nfa =
   nfa.transitions
   |> Array.for_all (fun delta ->
-         List.for_all (fun (label, _) -> Label.is_zero label) delta )
+    List.for_all (fun (label, _) -> Label.is_zero label) delta)
+;;
 
 let reenumerate map nfa =
   let transitions =
     nfa.transitions
     |> Array.map (fun delta ->
-           List.map (fun (label, q') -> (Label.reenumerate map label, q')) delta )
+      List.map (fun (label, q') -> Label.reenumerate map label, q') delta)
   in
-  { start= nfa.start
-  ; final= nfa.final
+  { start = nfa.start
+  ; final = nfa.final
   ; transitions
-  ; is_dfa= nfa.is_dfa
-  ; deg= Map.keys map |> List.fold_left max min_int }
+  ; is_dfa = nfa.is_dfa
+  ; deg = Map.keys map |> List.fold_left max min_int
+  }
+;;
 
 let project to_remove nfa =
   let transitions = nfa.transitions in
   Array.iteri
     (fun q delta ->
-      let project (label, q') = (Label.project to_remove label, q') in
-      Array.set transitions q (List.map project delta) )
+       let project (label, q') = Label.project to_remove label, q' in
+       Array.set transitions q (List.map project delta))
     transitions;
-  {final= nfa.final; start= nfa.start; transitions; deg= nfa.deg; is_dfa= false}
+  { final = nfa.final; start = nfa.start; transitions; deg = nfa.deg; is_dfa = false }
   |> update_final_states_nfa
+;;
 
 let truncate l nfa =
   let transitions = nfa.transitions in
   Array.iteri
     (fun q delta ->
-      let truncate (label, q') = (Label.truncate l label, q') in
-      Array.set transitions q (List.map truncate delta) )
+       let truncate (label, q') = Label.truncate l label, q' in
+       Array.set transitions q (List.map truncate delta))
     transitions;
-  {final= nfa.final; start= nfa.start; transitions; deg= l; is_dfa= false}
+  { final = nfa.final; start = nfa.start; transitions; deg = l; is_dfa = false }
   |> update_final_states_nfa
+;;
 
 let format_nfa ppf nfa =
   let format_state ppf state = fprintf ppf "%d" state in
@@ -404,52 +442,60 @@ let format_nfa ppf nfa =
   fprintf ppf "node [shape=circle]\n";
   Set.iter final ~f:(fprintf ppf "\"%a\" [shape=doublecircle]\n" format_state);
   Set.iter start ~f:(fprintf ppf "\"%a\" [shape=octagon]\n" format_state);
-  Set.iter start_final
-    ~f:(fprintf ppf "\"%a\" [shape=doubleoctagon]\n" format_state);
+  Set.iter start_final ~f:(fprintf ppf "\"%a\" [shape=doubleoctagon]\n" format_state);
   Array.iteri
     (fun q delta ->
-      delta
-      |> List.map (fun (label, q') -> (q', label))
-      |> Map.of_alist_multi
-      |> Map.iteri ~f:(fun ~key:q' ~data:labels ->
-             fprintf ppf "\"%a\" -> \"%a\" [label=\"%a\"]\n" format_state q
-               format_state q'
-               (Format.pp_print_list
-                  ~pp_sep:(fun ppf () -> Format.fprintf ppf "\n")
-                  Label.pp_label )
-               labels ) )
+       delta
+       |> List.map (fun (label, q') -> q', label)
+       |> Map.of_alist_multi
+       |> Map.iteri ~f:(fun ~key:q' ~data:labels ->
+         fprintf
+           ppf
+           "\"%a\" -> \"%a\" [label=\"%a\"]\n"
+           format_state
+           q
+           format_state
+           q'
+           (Format.pp_print_list
+              ~pp_sep:(fun ppf () -> Format.fprintf ppf "\n")
+              Label.pp_label)
+           labels))
     nfa.transitions;
   fprintf ppf "}"
+;;
 
 let reverse nfa =
   let transitions = Array.make (length nfa) [] in
   Array.iteri
     (fun q delta ->
-      List.iter
-        (fun (label, q') -> transitions.(q') <- (label, q) :: transitions.(q'))
-        delta )
+       List.iter
+         (fun (label, q') -> transitions.(q') <- (label, q) :: transitions.(q'))
+         delta)
     nfa.transitions;
-  {final= nfa.start; start= nfa.final; transitions; deg= nfa.deg; is_dfa= false}
+  { final = nfa.start; start = nfa.final; transitions; deg = nfa.deg; is_dfa = false }
+;;
 
 let to_dfa nfa =
   let counter = ref 0 in
   let rec aux transitions visited final queue =
-    if Queue.is_empty queue then (transitions, final)
-    else
+    if Queue.is_empty queue
+    then transitions, final
+    else (
       let qs = Queue.pop queue in
       let is_visited visited qs = Map.find visited qs |> Option.is_some in
       let visit visited qs =
-        if is_visited visited qs |> not then (
+        if is_visited visited qs |> not
+        then (
           let q = !counter in
           counter := !counter + 1;
-          Map.set visited ~key:qs ~data:q )
+          Map.set visited ~key:qs ~data:q)
         else visited
       in
       let visited = visit visited qs in
       let q visited qs = Map.find_exn visited qs in
       let final =
-        if Set.are_disjoint nfa.final qs |> not then
-          Set.add final (q visited qs)
+        if Set.are_disjoint nfa.final qs |> not
+        then Set.add final (q visited qs)
         else final
       in
       let acc =
@@ -458,44 +504,48 @@ let to_dfa nfa =
             let delta = Array.get nfa.transitions q in
             List.fold_left
               (fun acc (label, _) -> Label.combine acc label)
-              (Label.z nfa.deg) delta
-            |> Label.combine acc )
-          ~init:(Label.z nfa.deg) qs
+              (Label.z nfa.deg)
+              delta
+            |> Label.combine acc)
+          ~init:(Label.z nfa.deg)
+          qs
       in
       let variations = Label.variations acc in
       let delta, visited =
         List.fold_left
           (fun (acc, visited) label ->
-            let qs' =
-              Set.fold
-                ~f:(fun acc q ->
-                  let delta = Array.get nfa.transitions q in
-                  let q' =
-                    delta
-                    |> List.filter (fun (label', _) ->
-                           Label.equal label label' )
-                    |> List.map snd
-                  in
-                  List.append q' acc )
-                ~init:[] qs
-              |> Set.of_list
-            in
-            let is_visited = is_visited visited qs' in
-            let q visited qs = Map.find_exn visited qs in
-            let visited = visit visited qs' in
-            let q' = q visited qs' in
-            if is_visited |> not then Queue.add qs' queue;
-            ((label, q') :: acc, visited) )
-          ([], visited) variations
+             let qs' =
+               Set.fold
+                 ~f:(fun acc q ->
+                   let delta = Array.get nfa.transitions q in
+                   let q' =
+                     delta
+                     |> List.filter (fun (label', _) -> Label.equal label label')
+                     |> List.map snd
+                   in
+                   List.append q' acc)
+                 ~init:[]
+                 qs
+               |> Set.of_list
+             in
+             let is_visited = is_visited visited qs' in
+             let q visited qs = Map.find_exn visited qs in
+             let visited = visit visited qs' in
+             let q' = q visited qs' in
+             if is_visited |> not then Queue.add qs' queue;
+             (label, q') :: acc, visited)
+          ([], visited)
+          variations
       in
       let delta', final' = aux transitions visited final queue in
-      (delta :: delta', final')
+      delta :: delta', final')
   in
   let queue = Queue.create () in
   Queue.add nfa.start queue;
   let transitions, final = aux [] Map.empty Set.empty queue in
   let transitions = Array.of_list transitions in
-  {final; start= Set.singleton 0; transitions; deg= nfa.deg; is_dfa= true}
+  { final; start = Set.singleton 0; transitions; deg = nfa.deg; is_dfa = true }
+;;
 
 let minimize nfa = nfa |> to_dfa |> reverse |> to_dfa |> reverse |> to_dfa
 
@@ -505,7 +555,9 @@ let invert nfa =
   let states = states dfa in
   let final = Set.diff states dfa.final in
   { final
-  ; start= dfa.start
-  ; transitions= dfa.transitions
-  ; deg= dfa.deg
-  ; is_dfa= true }
+  ; start = dfa.start
+  ; transitions = dfa.transitions
+  ; deg = dfa.deg
+  ; is_dfa = true
+  }
+;;

--- a/lib/nfa.mli
+++ b/lib/nfa.mli
@@ -3,21 +3,19 @@ module Set = Base.Set.Poly
 module Sequence = Base.Sequence
 
 type state = int
-
 type deg = int
-
 type t
 
-val create_nfa :
-     transitions:(state * int * state) list
+val create_nfa
+  :  transitions:(state * int * state) list
   -> start:state list
   -> final:state list
   -> vars:int list
   -> deg:int
   -> t
 
-val create_dfa :
-     transitions:(state * int * state) list
+val create_dfa
+  :  transitions:(state * int * state) list
   -> start:state
   -> final:state list
   -> vars:int list
@@ -25,23 +23,13 @@ val create_dfa :
   -> t
 
 val run : t -> bool
-
 val intersect : t -> t -> t
-
 val unite : t -> t -> t
-
 val project : int list -> t -> t
-
 val truncate : int -> t -> t
-
 val is_graph : t -> bool
-
 val reenumerate : (int, int) Map.t -> t -> t
-
 val minimize : t -> t
-
 val invert : t -> t
-
 val format_nfa : Format.formatter -> t -> unit
-
 val remove_unreachable : t -> t

--- a/lib/optimizer.ml
+++ b/lib/optimizer.ml
@@ -1,60 +1,58 @@
 let contains var f =
   Ast.for_some
-    (function Ast.Exists (a, _) | Ast.Any (a, _) -> a = var | _ -> false)
-    (function Ast.Var a -> List.mem a var | _ -> false)
+    (function
+      | Ast.Exists (a, _) | Ast.Any (a, _) -> a = var
+      | _ -> false)
+    (function
+      | Ast.Var a -> List.mem a var
+      | _ -> false)
     f
+;;
 
 let move_quantifiers_closer formula =
   let rec aux f =
     let f' =
       Ast.map
         (function
-          | (Ast.Exists (x, f') | Ast.Any (x, f')) as f -> (
-              let quantifier_ast = Ast.quantifier_ast_exn f in
-              match f' with
-                | Ast.Mor (f1, f2)
-                | Ast.Mand (f1, f2)
-                | Ast.Miff (f1, f2)
-                | Ast.Mimpl (f1, f2) -> (
-                    let binconj_ast = Ast.binconj_ast_exn f' in
-                    let l1 = contains x f1 in
-                    let l2 = contains x f2 in
-                    match (l1, l2) with
-                      | true, true ->
-                          f
-                      | false, false ->
-                          f'
-                      | true, false ->
-                          binconj_ast (quantifier_ast x f1) f2
-                      | false, true ->
-                          binconj_ast f1 (quantifier_ast x f2) )
-                | _ ->
-                    if contains x f' then f else f' )
-          | _ as f ->
-              f )
-        Fun.id f
+          | (Ast.Exists (x, f') | Ast.Any (x, f')) as f ->
+            let quantifier_ast = Ast.quantifier_ast_exn f in
+            (match f' with
+             | Ast.Mor (f1, f2)
+             | Ast.Mand (f1, f2)
+             | Ast.Miff (f1, f2)
+             | Ast.Mimpl (f1, f2) ->
+               let binconj_ast = Ast.binconj_ast_exn f' in
+               let l1 = contains x f1 in
+               let l2 = contains x f2 in
+               (match l1, l2 with
+                | true, true -> f
+                | false, false -> f'
+                | true, false -> binconj_ast (quantifier_ast x f1) f2
+                | false, true -> binconj_ast f1 (quantifier_ast x f2))
+             | _ -> if contains x f' then f else f')
+          | _ as f -> f)
+        Fun.id
+        f
     in
     if f' = f then f' else aux f'
   in
   aux formula
+;;
 
 let quantifier_union f =
   Ast.map
     (function
-      | Ast.Exists (x, f') as f -> (
-        match f' with
-          | Ast.Exists (y, f'') ->
-              Ast.exists (List.append x y) f''
-          | _ ->
-              f )
-      | Ast.Any (x, f') as f -> (
-        match f' with
-          | Ast.Any (y, f'') ->
-              Ast.any (List.append x y) f''
-          | _ ->
-              f )
-      | _ as f ->
-          f )
-    Fun.id f
+      | Ast.Exists (x, f') as f ->
+        (match f' with
+         | Ast.Exists (y, f'') -> Ast.exists (List.append x y) f''
+         | _ -> f)
+      | Ast.Any (x, f') as f ->
+        (match f' with
+         | Ast.Any (y, f'') -> Ast.any (List.append x y) f''
+         | _ -> f)
+      | _ as f -> f)
+    Fun.id
+    f
+;;
 
 let optimize f = f |> move_quantifiers_closer |> quantifier_union

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -4,40 +4,52 @@
 
 open Angstrom
 
-let is_whitespace = function ' ' | '\t' | '\n' | '\r' -> true | _ -> false
+let is_whitespace = function
+  | ' ' | '\t' | '\n' | '\r' -> true
+  | _ -> false
+;;
 
 let whitespace = take_while is_whitespace
-
 let whitespace1 = take_while1 is_whitespace
 
-let is_digit = function '0' .. '9' -> true | _ -> false
+let is_digit = function
+  | '0' .. '9' -> true
+  | _ -> false
+;;
 
 let const = take_while1 is_digit >>| int_of_string >>| Ast.const
 
-let is_idschar = function 'a' .. 'z' | '_' -> true | _ -> false
+let is_idschar = function
+  | 'a' .. 'z' | '_' -> true
+  | _ -> false
+;;
 
-let is_idchar = function 'a' .. 'z' | '_' | '0' .. '9' -> true | _ -> false
+let is_idchar = function
+  | 'a' .. 'z' | '_' | '0' .. '9' -> true
+  | _ -> false
+;;
 
 let ident =
   let* a = satisfy is_idschar in
   let* b = take_while is_idchar in
   String.make 1 a ^ b |> return
+;;
 
 let var = ident >>| Ast.var
-
 let integer = take_while1 is_digit >>| int_of_string
-
 let parens p = char '(' *> whitespace *> p <* whitespace <* char ')'
 
 let chainl1 e op =
   let rec go acc = lift2 (fun f x -> f acc x) op e >>= go <|> return acc in
   e >>= go
+;;
 
 let un_op op ast p = string op *> whitespace *> p >>| ast
 
 let bin_op op ast p =
   let op = whitespace *> string op *> whitespace *> return ast in
   chainl1 p op
+;;
 
 let opt q p = q p <|> p
 
@@ -45,49 +57,63 @@ let pow term =
   let* c = integer <* whitespace in
   let* body = term in
   Ast.mul c body |> return
+;;
 
 let mul term =
   let* c = integer <* whitespace <* string "**" <* whitespace in
   let* body = term in
   Ast.pow c body |> return
+;;
 
 let term =
   fix (fun term ->
-      parens term <|> const <|> var |> opt pow |> opt mul |> bin_op "+" Ast.add )
+    parens term <|> const <|> var |> opt pow |> opt mul |> bin_op "+" Ast.add)
+;;
 
 let pred =
   let* name = ident <* whitespace in
   let* params = whitespace *> term |> many <* whitespace in
   Ast.pred name params |> return
+;;
 
 let pred_op op ast =
   let* a = term in
   let* _ = whitespace *> string op <* whitespace in
   let* b = term in
   ast a b |> return
+;;
 
 let aformula =
-  pred_op "=" Ast.eq <|> pred_op "!=" Ast.neq <|> pred_op "<" Ast.lt
-  <|> pred_op ">" Ast.gt <|> pred_op "<=" Ast.leq <|> pred_op ">=" Ast.geq
-  <|> pred <?> "Expected aformula"
+  pred_op "=" Ast.eq
+  <|> pred_op "!=" Ast.neq
+  <|> pred_op "<" Ast.lt
+  <|> pred_op ">" Ast.gt
+  <|> pred_op "<=" Ast.leq
+  <|> pred_op ">=" Ast.geq
+  <|> pred
+  <?> "Expected aformula"
+;;
 
 let quantifier sym ast formula =
   let* _ = char sym in
   let* var = ident in
   let* formula = whitespace *> formula in
-  ast [var] formula |> return
+  ast [ var ] formula |> return
+;;
 
 let formula =
   fix (fun formula ->
-      let formula1 =
-        parens formula <|> aformula
-        |> opt (un_op "~" Ast.mnot)
-        |> bin_op "&" Ast.mand |> bin_op "|" Ast.mor |> bin_op "->" Ast.mimpl
-        |> bin_op "<->" Ast.miff
-      in
-      quantifier 'A' Ast.any formula
-      <|> quantifier 'E' Ast.exists formula
-      <|> formula1 )
+    let formula1 =
+      parens formula
+      <|> aformula
+      |> opt (un_op "~" Ast.mnot)
+      |> bin_op "&" Ast.mand
+      |> bin_op "|" Ast.mor
+      |> bin_op "->" Ast.mimpl
+      |> bin_op "<->" Ast.miff
+    in
+    quantifier 'A' Ast.any formula <|> quantifier 'E' Ast.exists formula <|> formula1)
+;;
 
 let kw kw ast = string kw *> whitespace *> return ast
 
@@ -95,11 +121,13 @@ let kw1 kw ast p1 =
   let* _ = string kw <* whitespace1 in
   let* p1 = p1 in
   ast p1 |> return
+;;
 
 let kw2 kw ast p1 p2 =
   let* _ = string kw <* whitespace1 in
   let* p1 = p1 in
   ast p1 p2
+;;
 
 let kw3 kw ast p1 p2 p3 =
   let* _ = string kw <* whitespace1 in
@@ -107,46 +135,59 @@ let kw3 kw ast p1 p2 p3 =
   let* p2 = p2 in
   let* p3 = p3 in
   ast p1 p2 p3 |> return
+;;
 
 let def =
   let* name = string "let" *> whitespace *> ident <* whitespace in
   let* params = many (whitespace *> ident) in
   let* body = whitespace *> char '=' *> whitespace *> formula in
   Ast.def name params body |> return
+;;
 
 let stmt =
   kw1 "eval" Ast.eval formula
   <|> kw1 "evalsemenov" Ast.evalsemenov formula
-  <|> kw3 "let" Ast.def (ident <* whitespace)
+  <|> kw3
+        "let"
+        Ast.def
+        (ident <* whitespace)
         (many (whitespace *> ident))
         (whitespace *> char '=' *> whitespace *> formula)
   <|> kw1 "dump" Ast.dump formula
   <|> kw1 "parse" Ast.parse formula
-  <|> kw "list" Ast.list <|> kw "help" Ast.help <?> "Unknown statement"
+  <|> kw "list" Ast.list
+  <|> kw "help" Ast.help
+  <?> "Unknown statement"
+;;
 
 let parse_formula str = parse_string ~consume:Prefix formula str
-
 let parse str = parse_string ~consume:Prefix stmt str
 
 let%expect_test "parse simple formula" =
-  Format.printf "%a" Ast.pp_formula
-    (parse_formula {|Ax x = 2 | x != 2|} |> Result.get_ok);
+  Format.printf "%a" Ast.pp_formula (parse_formula {|Ax x = 2 | x != 2|} |> Result.get_ok);
   [%expect {| (Ax ((x = 2) | (x != 2))) |}]
+;;
 
 let%expect_test "parse multiple quantifier formula" =
-  Format.printf "%a" Ast.pp_formula
-    (parse_formula {|ExEy z = 5x + 3y|} |> Result.get_ok);
+  Format.printf "%a" Ast.pp_formula (parse_formula {|ExEy z = 5x + 3y|} |> Result.get_ok);
   [%expect {| (Ex (Ey (z = ((5 * x) + (3 * y))))) |}]
+;;
 
 let%expect_test "parse long chain" =
-  Format.printf "%a" Ast.pp_formula
+  Format.printf
+    "%a"
+    Ast.pp_formula
     (parse_formula {|x = 2 & y = 3 & z = 4 & a = 1 & b = 5|} |> Result.get_ok);
   [%expect {| (((((x = 2) & (y = 3)) & (z = 4)) & (a = 1)) & (b = 5)) |}]
+;;
 
 let%expect_test "parse parens and complex priorities" =
-  Format.printf "%a" Ast.pp_formula
-    ( parse_formula
-        {|a = 1 & b = 2 & (t + 2(z + 3q) + (2d + 5w) >= 15 | (Ex Ey x + y = 15))|}
-    |> Result.get_ok );
+  Format.printf
+    "%a"
+    Ast.pp_formula
+    (parse_formula
+       {|a = 1 & b = 2 & (t + 2(z + 3q) + (2d + 5w) >= 15 | (Ex Ey x + y = 15))|}
+     |> Result.get_ok);
   [%expect
     {| (((a = 1) & (b = 2)) & ((((t + (2 * (z + (3 * q)))) + ((2 * d) + (5 * w))) >= 15) | (Ex (Ey ((x + y) = 15))))) |}]
+;;

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -2,360 +2,429 @@ module Set = Base.Set.Poly
 module Map = Base.Map.Poly
 
 type t =
-  { preds:
-      (string * string list * Ast.formula * Nfa.t * (string, int) Map.t) list
-  ; vars: (string, int) Map.t
-  ; total: int
-  ; progress: int }
+  { preds : (string * string list * Ast.formula * Nfa.t * (string, int) Map.t) list
+  ; vars : (string, int) Map.t
+  ; total : int
+  ; progress : int
+  }
 
 let ( let* ) = Result.bind
-
 let return = Result.ok
-
 let throw_if cond a = if cond then Result.error a else Result.ok ()
-
-let default_s () = {preds= []; vars= Map.empty; total= 0; progress= 0}
-
+let default_s () = { preds = []; vars = Map.empty; total = 0; progress = 0 }
 let s = ref (default_s ())
 
 let collect f =
   Ast.fold
     (fun acc ast ->
-      match ast with
-        | Ast.Exists (xs, _) | Ast.Any (xs, _) ->
-            Set.union acc (Set.of_list xs)
-        | Ast.Pred (_, _) ->
-            acc
-        | _ ->
-            acc )
+       match ast with
+       | Ast.Exists (xs, _) | Ast.Any (xs, _) -> Set.union acc (Set.of_list xs)
+       | Ast.Pred (_, _) -> acc
+       | _ -> acc)
     (fun acc x ->
-      match x with
-        | Ast.Var x ->
-            Set.add acc x
-        | Ast.Pow (_, x) -> (
-          match x with
-            | Ast.Var x ->
-                Set.add acc ("2**" ^ x)
-            | _ ->
-                failwith "unimplemented" )
-        | _ ->
-            acc )
-    Set.empty f
+       match x with
+       | Ast.Var x -> Set.add acc x
+       | Ast.Pow (_, x) ->
+         (match x with
+          | Ast.Var x -> Set.add acc ("2**" ^ x)
+          | _ -> failwith "unimplemented")
+       | _ -> acc)
+    Set.empty
+    f
+;;
 
 let _estimate f = Ast.fold (fun acc _ -> acc + 1) (fun acc _ -> acc + 1) 0 f
-
 let internal_counter = ref 0
 
 let internal s =
   internal_counter := !internal_counter + 1;
   !internal_counter - 1 + Map.length s.vars
+;;
 
 let teval s ast =
   let var_exn v = Map.find_exn s.vars v in
   let rec teval ast =
     match ast with
-      | Ast.Var a ->
-          let var = var_exn a in
-          (var, NfaCollection.n ())
-      | Ast.Const a ->
+    | Ast.Var a ->
+      let var = var_exn a in
+      var, NfaCollection.n ()
+    | Ast.Const a ->
+      let var = internal s in
+      var, NfaCollection.eq_const var a
+    | Ast.Add (l, r) ->
+      let lv, la = teval l in
+      let rv, ra = teval r in
+      let res = internal s in
+      ( res
+      , NfaCollection.add ~lhs:lv ~rhs:rv ~sum:res |> Nfa.intersect la |> Nfa.intersect ra
+      )
+    | Ast.Mul (a, b) ->
+      let rec teval_mul a b =
+        match a with
+        | 0 ->
           let var = internal s in
-          (var, NfaCollection.eq_const var a)
-      | Ast.Add (l, r) ->
-          let lv, la = teval l in
-          let rv, ra = teval r in
-          let res = internal s in
-          ( res
-          , NfaCollection.add ~lhs:lv ~rhs:rv ~sum:res
-            |> Nfa.intersect la |> Nfa.intersect ra )
-      | Ast.Mul (a, b) ->
-          let rec teval_mul a b =
-            match a with
-              | 0 ->
-                  let var = internal s in
-                  (var, NfaCollection.eq_const var 0)
-              | 1 ->
-                  teval b
-              | _ -> (
-                match a mod 2 with
-                  | 0 ->
-                      let tv, ta = teval_mul (a / 2) b in
-                      let res = internal s in
-                      ( res
-                      , NfaCollection.add ~lhs:tv ~rhs:tv ~sum:res
-                        |> Nfa.intersect ta )
-                  | 1 ->
-                      let tv, ta = teval_mul (a - 1) b in
-                      let uv, ua = teval b in
-                      let res = internal s in
-                      ( res
-                      , NfaCollection.add ~lhs:tv ~rhs:uv ~sum:res
-                        |> Nfa.intersect ta |> Nfa.intersect ua )
-                  | _ ->
-                      assert false )
-          in
-          let v, nfa = teval_mul a b in
-          (v, nfa)
-      | Ast.Pow (_, x) -> (
-        match x with
-          | Ast.Var x ->
-              (var_exn ("2**" ^ x), NfaCollection.n ())
-          | _ ->
-              failwith "unimplemented" )
+          var, NfaCollection.eq_const var 0
+        | 1 -> teval b
+        | _ ->
+          (match a mod 2 with
+           | 0 ->
+             let tv, ta = teval_mul (a / 2) b in
+             let res = internal s in
+             res, NfaCollection.add ~lhs:tv ~rhs:tv ~sum:res |> Nfa.intersect ta
+           | 1 ->
+             let tv, ta = teval_mul (a - 1) b in
+             let uv, ua = teval b in
+             let res = internal s in
+             ( res
+             , NfaCollection.add ~lhs:tv ~rhs:uv ~sum:res
+               |> Nfa.intersect ta
+               |> Nfa.intersect ua )
+           | _ -> assert false)
+      in
+      let v, nfa = teval_mul a b in
+      v, nfa
+    | Ast.Pow (_, x) ->
+      (match x with
+       | Ast.Var x -> var_exn ("2**" ^ x), NfaCollection.n ()
+       | _ -> failwith "unimplemented")
   in
   let nfa = teval ast in
   nfa
+;;
 
 let eval s ast =
   let vars =
-    collect ast |> Set.to_list
-    |> List.mapi (fun i x -> (x, i))
-    |> Map.of_alist_exn
+    collect ast |> Set.to_list |> List.mapi (fun i x -> x, i) |> Map.of_alist_exn
   in
-  let s = {preds= s.preds; vars; total= 0; progress= 0} in
+  let s = { preds = s.preds; vars; total = 0; progress = 0 } in
   let deg () = Map.length s.vars in
   let var_exn v = Map.find_exn s.vars v in
   let reset_internals () = internal_counter := Map.length s.vars in
   let rec eval ast =
     let nfa =
       match ast with
-        | Ast.True ->
-            NfaCollection.n () |> return
-        | Ast.False ->
-            NfaCollection.z () |> return
-        | Ast.Eq (l, r) ->
-            let lv, la = teval s l in
-            let rv, ra = teval s r in
-            reset_internals ();
-            NfaCollection.eq lv rv |> Nfa.intersect la |> Nfa.intersect ra
-            |> Nfa.truncate (deg ())
-            |> return
-        | Ast.Leq (l, r) ->
-            let lv, la = teval s l in
-            let rv, ra = teval s r in
-            reset_internals ();
-            NfaCollection.leq lv rv |> Nfa.intersect la |> Nfa.intersect ra
-            |> Nfa.truncate (deg ())
-            |> return
-        | Ast.Geq (l, r) ->
-            let lv, la = teval s l in
-            let rv, ra = teval s r in
-            reset_internals ();
-            NfaCollection.geq lv rv |> Nfa.intersect la |> Nfa.intersect ra
-            |> Nfa.truncate (deg ())
-            |> return
-        | Ast.Lt (l, r) ->
-            let lv, la = teval s l in
-            let rv, ra = teval s r in
-            reset_internals ();
-            NfaCollection.lt lv rv |> Nfa.intersect la |> Nfa.intersect ra
-            |> Nfa.truncate (deg ())
-            |> return
-        | Ast.Gt (l, r) ->
-            let lv, la = teval s l in
-            let rv, ra = teval s r in
-            reset_internals ();
-            NfaCollection.gt lv rv |> Nfa.intersect la |> Nfa.intersect ra
-            |> Nfa.truncate (deg ())
-            |> return
-        | Ast.Mnot f ->
-            let* nfa = eval f in
-            nfa |> Nfa.invert |> return
-        | Ast.Mand (f1, f2) ->
-            let* la = eval f1 in
-            let* ra = eval f2 in
-            Nfa.intersect la ra |> return
-        | Ast.Mor (f1, f2) ->
-            let* la = eval f1 in
-            let* ra = eval f2 in
-            Nfa.unite la ra |> return
-        | Ast.Mimpl (f1, f2) ->
-            let* la = eval f1 in
-            let* ra = eval f2 in
-            Nfa.unite (la |> Nfa.invert) ra |> return
-        | Ast.Exists (x, f) ->
-            let* nfa = eval f in
-            let x = List.map var_exn x in
-            nfa |> Nfa.project x |> return
-        | Ast.Any (x, f) ->
-            let* nfa = eval f in
-            let x = List.map var_exn x in
-            nfa |> Nfa.invert |> Nfa.project x |> Nfa.invert |> return
-        | Ast.Pred (name, args) ->
-            let* _, pred_params, _, pred_nfa, pred_vars =
-              List.find_opt
-                (fun (pred_name, _, _, _, _) -> pred_name = name)
-                s.preds
-              |> Option.to_result
-                   ~none:(Format.sprintf "Unknown predicate: %s" name)
-            in
-            let args = List.map (teval s) args in
-            reset_internals ();
-            let map =
-              List.mapi
-                (fun i (v, _) ->
-                  (v, List.nth pred_params i |> Map.find_exn pred_vars) )
-                args
-              |> Map.of_alist_exn
-            in
-            let nfa = pred_nfa |> Nfa.reenumerate map in
-            List.fold_left Nfa.intersect nfa (List.map snd args) |> return
-        | _ ->
-            failwith "unimplemented"
+      | Ast.True -> NfaCollection.n () |> return
+      | Ast.False -> NfaCollection.z () |> return
+      | Ast.Eq (l, r) ->
+        let lv, la = teval s l in
+        let rv, ra = teval s r in
+        reset_internals ();
+        NfaCollection.eq lv rv
+        |> Nfa.intersect la
+        |> Nfa.intersect ra
+        |> Nfa.truncate (deg ())
+        |> return
+      | Ast.Leq (l, r) ->
+        let lv, la = teval s l in
+        let rv, ra = teval s r in
+        reset_internals ();
+        NfaCollection.leq lv rv
+        |> Nfa.intersect la
+        |> Nfa.intersect ra
+        |> Nfa.truncate (deg ())
+        |> return
+      | Ast.Geq (l, r) ->
+        let lv, la = teval s l in
+        let rv, ra = teval s r in
+        reset_internals ();
+        NfaCollection.geq lv rv
+        |> Nfa.intersect la
+        |> Nfa.intersect ra
+        |> Nfa.truncate (deg ())
+        |> return
+      | Ast.Lt (l, r) ->
+        let lv, la = teval s l in
+        let rv, ra = teval s r in
+        reset_internals ();
+        NfaCollection.lt lv rv
+        |> Nfa.intersect la
+        |> Nfa.intersect ra
+        |> Nfa.truncate (deg ())
+        |> return
+      | Ast.Gt (l, r) ->
+        let lv, la = teval s l in
+        let rv, ra = teval s r in
+        reset_internals ();
+        NfaCollection.gt lv rv
+        |> Nfa.intersect la
+        |> Nfa.intersect ra
+        |> Nfa.truncate (deg ())
+        |> return
+      | Ast.Mnot f ->
+        let* nfa = eval f in
+        nfa |> Nfa.invert |> return
+      | Ast.Mand (f1, f2) ->
+        let* la = eval f1 in
+        let* ra = eval f2 in
+        Nfa.intersect la ra |> return
+      | Ast.Mor (f1, f2) ->
+        let* la = eval f1 in
+        let* ra = eval f2 in
+        Nfa.unite la ra |> return
+      | Ast.Mimpl (f1, f2) ->
+        let* la = eval f1 in
+        let* ra = eval f2 in
+        Nfa.unite (la |> Nfa.invert) ra |> return
+      | Ast.Exists (x, f) ->
+        let* nfa = eval f in
+        let x = List.map var_exn x in
+        nfa |> Nfa.project x |> return
+      | Ast.Any (x, f) ->
+        let* nfa = eval f in
+        let x = List.map var_exn x in
+        nfa |> Nfa.invert |> Nfa.project x |> Nfa.invert |> return
+      | Ast.Pred (name, args) ->
+        let* _, pred_params, _, pred_nfa, pred_vars =
+          List.find_opt (fun (pred_name, _, _, _, _) -> pred_name = name) s.preds
+          |> Option.to_result ~none:(Format.sprintf "Unknown predicate: %s" name)
+        in
+        let args = List.map (teval s) args in
+        reset_internals ();
+        let map =
+          List.mapi
+            (fun i (v, _) -> v, List.nth pred_params i |> Map.find_exn pred_vars)
+            args
+          |> Map.of_alist_exn
+        in
+        let nfa = pred_nfa |> Nfa.reenumerate map in
+        List.fold_left Nfa.intersect nfa (List.map snd args) |> return
+      | _ -> failwith "unimplemented"
     in
     nfa
   in
   let* res = eval ast in
   (res, vars) |> return
+;;
 
 let ( let* ) = Result.bind
 
 let dump f =
   let* nfa, _ = eval !s f in
   Format.asprintf "%a" Nfa.format_nfa (nfa |> Nfa.minimize) |> return
+;;
 
 let list () =
   let rec aux = function
-    | [] ->
-        ()
+    | [] -> ()
     | (name, params, f, _, _) :: xs ->
-        Format.printf "%s %a = %a\n%!" name
-          (Format.pp_print_list Format.pp_print_string)
-          params Ast.pp_formula f;
-        aux xs
+      Format.printf
+        "%s %a = %a\n%!"
+        name
+        (Format.pp_print_list Format.pp_print_string)
+        params
+        Ast.pp_formula
+        f;
+      aux xs
   in
   aux !s.preds
+;;
 
 let pred name params f =
   let* nfa, vars = eval !s f in
-  s :=
-    { preds= (name, params, f, nfa, vars) :: !s.preds
-    ; total= !s.total
-    ; vars= !s.vars
-    ; progress= !s.progress };
+  s
+  := { preds = (name, params, f, nfa, vars) :: !s.preds
+     ; total = !s.total
+     ; vars = !s.vars
+     ; progress = !s.progress
+     };
   return ()
+;;
 
 let proof f =
   let* _ =
     throw_if
       (Ast.for_some
          (fun _ -> false)
-         (function Ast.Pow (_, _) -> true | _ -> false)
-         f )
+         (function
+           | Ast.Pow (_, _) -> true
+           | _ -> false)
+         f)
       ""
   in
   let* nfa, _ = f |> eval !s in
   Nfa.run nfa |> return
+;;
 
 let proof_semenov f =
   let* nfa, _ = f |> eval !s in
   Nfa.run nfa |> return
+;;
 
-let%expect_test
-    "Proof any x > 7 can be represented as a linear combination of 3 and 5" =
-  Format.printf "%b"
-    ( {|AxEyEz x = 3y + 5z | x <= 7|} |> Parser.parse_formula |> Result.get_ok
-    |> proof |> Result.get_ok );
+let%expect_test "Proof any x > 7 can be represented as a linear combination of 3 and 5" =
+  Format.printf
+    "%b"
+    ({|AxEyEz x = 3y + 5z | x <= 7|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   [%expect {| true |}]
+;;
 
-let%expect_test
-    "Disproof any x > 6 can be represented as a linear combination of 3 and 5" =
-  Format.printf "%b"
-    ( {|AxEyEz x = 3y + 5z | x <= 6|} |> Parser.parse_formula |> Result.get_ok
-    |> proof |> Result.get_ok );
+let%expect_test "Disproof any x > 6 can be represented as a linear combination of 3 and 5"
+  =
+  Format.printf
+    "%b"
+    ({|AxEyEz x = 3y + 5z | x <= 6|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   [%expect {| false |}]
+;;
 
 let%expect_test "Proof for all x exists x + 1" =
-  Format.printf "%b"
-    ( {|AxEy y = x + 1|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|AxEy y = x + 1|} |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Disproof for all x exists x - 1" =
-  Format.printf "%b"
-    ( {|AxEy x = y + 1|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|AxEy x = y + 1|} |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok);
   [%expect {| false |}]
+;;
 
 let%expect_test "Proof simple existential formula" =
-  Format.printf "%b"
-    ( {|ExEy 15 = x + y & y <= 10|} |> Parser.parse_formula |> Result.get_ok
-    |> proof |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|ExEy 15 = x + y & y <= 10|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Proof simple any quantified formula" =
-  Format.printf "%b"
-    ( {|Ax x = 2 | ~(x = 2)|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|Ax x = 2 | ~(x = 2)|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Proof 2 <= 3" =
-  Format.printf "%b"
-    ( {|2 <= 3|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|2 <= 3|} |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Proof zero is the least" =
-  Format.printf "%b"
-    ( {|Ax x >= 0|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|Ax x >= 0|} |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Disproof 3 >= 15" =
-  Format.printf "%b"
-    ( {|3 >= 15|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|3 >= 15|} |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok);
   [%expect {| false |}]
+;;
 
 let%expect_test "Proof less than 1 is zero" =
-  Format.printf "%b"
-    ( {|Ax x < 1 -> x = 0|} |> Parser.parse_formula |> Result.get_ok |> proof
-    |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|Ax x < 1 -> x = 0|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Proof if x > 3 and y > 4 then x + y > 7" =
-  Format.printf "%b"
-    ( {|AxAy x > 3 & y > 4 -> x + y > 7|} |> Parser.parse_formula
-    |> Result.get_ok |> proof |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|AxAy x > 3 & y > 4 -> x + y > 7|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   [%expect {| true |}]
+;;
 
 let%expect_test "Proof sum of two even is even" =
   s := default_s ();
-  {|Ey x = 2y|} |> Parser.parse_formula |> Result.get_ok |> pred "even" ["x"]
+  {|Ey x = 2y|}
+  |> Parser.parse_formula
+  |> Result.get_ok
+  |> pred "even" [ "x" ]
   |> Result.get_ok;
-  Format.printf "%b"
-    ( {|AxAyAz x + y = z & even(x) & even(y) -> even(z)|}
-    |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|AxAyAz x + y = z & even(x) & even(y) -> even(z)|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   s := default_s ();
   [%expect {| true |}]
+;;
 
 let%expect_test "Proof sum of two even plus one is odd" =
   s := default_s ();
-  {|Ey x = 2y|} |> Parser.parse_formula |> Result.get_ok |> pred "even" ["x"]
+  {|Ey x = 2y|}
+  |> Parser.parse_formula
+  |> Result.get_ok
+  |> pred "even" [ "x" ]
   |> Result.get_ok;
-  Format.printf "%b"
-    ( {|AxAyAz x + y = z & even(x) & even(y) -> ~even(z + 1)|}
-    |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|AxAyAz x + y = z & even(x) & even(y) -> ~even(z + 1)|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   s := default_s ();
   [%expect {| true |}]
+;;
 
 let%expect_test "Disproof sum of two even plus one is even" =
   s := default_s ();
-  {|Ey x = 2y|} |> Parser.parse_formula |> Result.get_ok |> pred "even" ["x"]
+  {|Ey x = 2y|}
+  |> Parser.parse_formula
+  |> Result.get_ok
+  |> pred "even" [ "x" ]
   |> Result.get_ok;
-  Format.printf "%b"
-    ( {|AxAyAz x + y = z & even(x) & even(y) -> even(z + 1)|}
-    |> Parser.parse_formula |> Result.get_ok |> proof |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|AxAyAz x + y = z & even(x) & even(y) -> even(z + 1)|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   s := default_s ();
   [%expect {| false |}]
+;;
 
 let%expect_test "Proof a number is even iff it's not odd" =
   s := default_s ();
-  {|Ey x = 2y|} |> Parser.parse_formula |> Result.get_ok |> pred "even" ["x"]
+  {|Ey x = 2y|}
+  |> Parser.parse_formula
+  |> Result.get_ok
+  |> pred "even" [ "x" ]
   |> Result.get_ok;
-  {|Ey x = 2y + 1|} |> Parser.parse_formula |> Result.get_ok |> pred "odd" ["x"]
+  {|Ey x = 2y + 1|}
+  |> Parser.parse_formula
+  |> Result.get_ok
+  |> pred "odd" [ "x" ]
   |> Result.get_ok;
-  Format.printf "%b"
-    ( {|Ax (even(x) -> ~odd(x)) & (~odd(x) -> even(x))|} |> Parser.parse_formula
-    |> Result.get_ok |> proof |> Result.get_ok );
+  Format.printf
+    "%b"
+    ({|Ax (even(x) -> ~odd(x)) & (~odd(x) -> even(x))|}
+     |> Parser.parse_formula
+     |> Result.get_ok
+     |> proof
+     |> Result.get_ok);
   s := default_s ();
   [%expect {| true |}]
+;;

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,9 +1,5 @@
 val list : unit -> unit
-
 val pred : string -> string list -> Ast.formula -> (unit, string) result
-
 val dump : Ast.formula -> (string, string) result
-
 val proof : Ast.formula -> (bool, string) result
-
 val proof_semenov : Ast.formula -> (bool, string) result

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -2,9 +2,9 @@ module Map = Base.Map.Poly
 
 let ( let* ) = Option.bind
 
-let option_map_to_map_option (map : ('a, 'b option) Map.t) :
-    ('a, 'b) Map.t option =
+let option_map_to_map_option (map : ('a, 'b option) Map.t) : ('a, 'b) Map.t option =
   Map.fold map ~init:(Some Map.empty) ~f:(fun ~key ~data acc ->
-      let* acc = acc in
-      let* data = data in
-      Some (Map.set ~key ~data acc) )
+    let* acc = acc in
+    let* data = data in
+    Some (Map.set ~key ~data acc))
+;;


### PR DESCRIPTION
This patch switches default code formatting to a JaneStreet formatting style. It feels a lot more compact than the previously used `ocamlformat` formatting style setting.

For example.

```diff
 let rec pp_term ppf = function
-  | Var n ->
-      Format.fprintf ppf "%s" n
-  | Const n ->
-      Format.fprintf ppf "%d" n
-  | Add (a, b) ->
-      Format.fprintf ppf "(%a + %a)" pp_term a pp_term b
-  | Mul (a, b) ->
-      Format.fprintf ppf "(%d * %a)" a pp_term b
-  | Pow (a, b) ->
-      Format.fprintf ppf "(%d ** %a)" a pp_term b
+  | Var n -> Format.fprintf ppf "%s" n
+  | Const n -> Format.fprintf ppf "%d" n
+  | Add (a, b) -> Format.fprintf ppf "(%a + %a)" pp_term a pp_term b
+  | Mul (a, b) -> Format.fprintf ppf "(%d * %a)" a pp_term b
+  | Pow (a, b) -> Format.fprintf ppf "(%d ** %a)" a pp_term b
+;;
```

Closes #29