### PR TITLE
solver: support getting a model for PrA formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Commands supported by the REPL and their semantics:
 - `let <name> <params...> = <FOL formula>` - define a new predicate.
 - `list` - list existing predicates.
 - `eval <formula>` - prove a theorem.
+- `evalm <formula>` - get a model for free variables in a formula.
 - `evalsemenov <formula>` - prove an existential Semёnov arithmetic theorem.
 - `dump <FOL formula>` - display the automaton for the desired FOL formula using GraphViz.
 - `parse <FOL formula>` - display the AST tree for the FOL formula.

--- a/bin/mandms.ml
+++ b/bin/mandms.ml
@@ -3,12 +3,23 @@
 (** SPDX-License-Identifier: MIT *)
 
 open Lib
+module Map = Base.Map.Poly
 
 let exec line = function
   | Ast.Eval f ->
     let res = Solver.proof f in
     (match res with
      | Ok res -> Format.printf "Result: %b\n\n%!" res
+     | Error msg -> Format.printf "Error: %s\n\n%!" msg)
+  | Ast.Evalm f ->
+    let res = Solver.get_model f in
+    (match res with
+     | Ok res ->
+       (match res with
+        | Some model ->
+          Map.iteri ~f:(fun ~key:k ~data:v -> Format.printf "%s = %d  " k v) model;
+          Format.printf "\n%!"
+        | None -> Format.printf "No model\n\n%!")
      | Error msg -> Format.printf "Error: %s\n\n%!" msg)
   | Ast.EvalSemenov f ->
     let res = Solver.proof_semenov f in

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -35,6 +35,7 @@ type formula =
 type stmt =
   | Def of string * varname list * formula
   | Eval of formula
+  | Evalm of formula
   | EvalSemenov of formula
   | Dump of formula
   | Parse of formula

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -35,6 +35,7 @@ type formula =
 type stmt =
   | Def of string * varname list * formula
   | Eval of formula
+  | Evalm of formula
   | EvalSemenov of formula
   | Dump of formula
   | Parse of formula

--- a/lib/nfa.mli
+++ b/lib/nfa.mli
@@ -23,6 +23,7 @@ val create_dfa
   -> t
 
 val run : t -> bool
+val any_path : t -> int list -> int list option
 val intersect : t -> t -> t
 val unite : t -> t -> t
 val project : int list -> t -> t

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -146,6 +146,7 @@ let def =
 
 let stmt =
   kw1 "eval" Ast.eval formula
+  <|> kw1 "evalm" Ast.evalm formula
   <|> kw1 "evalsemenov" Ast.evalsemenov formula
   <|> kw3
         "let"

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,5 +1,8 @@
+module Map = Base.Map.Poly
+
 val list : unit -> unit
 val pred : string -> string list -> Ast.formula -> (unit, string) result
 val dump : Ast.formula -> (string, string) result
 val proof : Ast.formula -> (bool, string) result
+val get_model : Ast.formula -> ((string, int) Map.t option, string) result
 val proof_semenov : Ast.formula -> (bool, string) result


### PR DESCRIPTION
This patch allows user to find a model for free variables of a formula by running `evalm formula`.

Example.

```
> evalm (Ex y = 15x) & y > 64 & y < 128
  y = 75
```

Basically, the model is sought by evaluating deep-first traversal of the resulting automaton from one of the starting states to one of the final ones and then collecting the labels into integer values.

Semёnov arithmetic support will be added later.