### PR TITLE
ci: deduplicate pull request checks

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,10 @@
 name: Build on linux
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build-linux:


### PR DESCRIPTION
This patch removes duplicating checks both on push and on pull request
when pushing into the pull request by making the workflow trigger only
on push in the master branch.
