### PR TITLE
solver: speedup Semenov arithmetic

### DIFF
--- a/bin/smtlib.ml
+++ b/bin/smtlib.ml
@@ -103,8 +103,8 @@ let rec formula s = function
      | "<" -> top2 Ast.lt
      | ">" -> top2 Ast.gt
      | "not" -> fop1 Ast.mnot
-     | "and" -> fop2 Ast.mand
-     | "or" -> fop2 Ast.mor
+     | "and" -> cf Ast.mand
+     | "or" -> cf Ast.mor
      | "=>" -> fop2 Ast.mimpl
      | _ -> Result.error "uninmplemented")
     (* TODO: string is ignored *)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -147,14 +147,9 @@ let formula =
     ast [ var ] formula |> return
   in
   fix (fun formula ->
-    let formula0 =
-      let* c = peek_char_fail in
-      match c with
-      | '(' -> parens formula
-      | _ -> aformula
-    in
     let formula1 =
-      formula0
+      parens formula
+      <|> aformula
       |> opt (un_op "~" Ast.mnot)
       |> bin_op "&" Ast.mand
       |> bin_op "|" Ast.mor


### PR DESCRIPTION
This patch drastically speedups Semenov arithmetic evaluation. Now the
variables that aren't used within the `2**` functional symbol are
automatically projected and ignored while trying different orders.

This means it's a lot less orders in general to try to.

It also contains some small fix ups: `and` and `or` in smtlib can now
contain arbitrary amount of arguments.

Also, the parser now properly handles open parens when in formulas.
