### PR TITLE
smtlib: add bitwise operations

### DIFF
--- a/MacadamiaSolver.opam
+++ b/MacadamiaSolver.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "3.16"}
   "angstrom"
   "bitv"
+  "ppx_regexp"
   "ppx_deriving"
   "ppx_variants_conv"
   "ppx_expect" {with-test}

--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,7 @@
   dune
   angstrom
   bitv
+  ppx_regexp
   ppx_deriving
   ppx_variants_conv
   (ppx_expect :with-test)

--- a/examples/basic-bitvector-bitwise.smt2
+++ b/examples/basic-bitvector-bitwise.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(declare-fun s () (_ BitVec 512))
+(declare-fun t () (_ BitVec 512))
+(assert (and (= (bv2nat (bvand s t)) 3) (> (bv2nat t) 15)))
+(check-sat)
+(get-model)

--- a/lib/NfaCollection.mli
+++ b/lib/NfaCollection.mli
@@ -1,7 +1,8 @@
 type varpos = int
 
-val add : lhs:varpos -> rhs:varpos -> sum:varpos -> Nfa.t
+val add : lhs:varpos -> rhs:varpos -> res:varpos -> Nfa.t
 val eq : varpos -> varpos -> Nfa.t
+val neq : varpos -> varpos -> Nfa.t
 val eq_const : varpos -> int -> Nfa.t
 val n : unit -> Nfa.t
 val z : unit -> Nfa.t
@@ -13,3 +14,6 @@ val torename : varpos -> int -> int -> Nfa.t
 val torename2 : int -> int -> Nfa.t
 val power_of_two : int -> Nfa.t
 val mul : res:varpos -> lhs:int -> rhs:varpos -> Nfa.t
+val bvor : lhs:varpos -> rhs:varpos -> res:varpos -> Nfa.t
+val bvand : lhs:varpos -> rhs:varpos -> res:varpos -> Nfa.t
+val bvxor : lhs:varpos -> rhs:varpos -> res:varpos -> Nfa.t

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -10,6 +10,9 @@ type term =
   | Const of int
   | Add of term * term
   | Mul of int * term
+  | Bvand of term * term
+  | Bvor of term * term
+  | Bvxor of term * term
   | Pow of int * term
 [@@deriving variants]
 

--- a/lib/dune
+++ b/lib/dune
@@ -19,4 +19,5 @@
    ppx_variants_conv
    ppx_inline_test
    ppx_assert
-   ppx_expect)))
+   ppx_expect
+   ppx_regexp)))

--- a/lib/smtlib.ml
+++ b/lib/smtlib.ml
@@ -226,7 +226,12 @@ let term =
     let complex_term' =
       let* keyword = take_while1 is_symbolchar <* whitespace in
       match keyword with
-      | "let" -> fail "unimplemented"
+      | "let" ->
+        let* bindings =
+          many1 (lift2 (fun a b -> a, b) identifier term |> parens) |> parens
+        in
+        let* term = term in
+        let' bindings term |> return
       | "exists" ->
         let* vars = many1 (sorted_var <* whitespace) |> parens in
         let* term = term in

--- a/tests/dune
+++ b/tests/dune
@@ -5,4 +5,5 @@
   ./examples/fcp_2_4.smt2
   ./examples/bad-exp.smt2
   ./examples/basic-exp-unsat.smt2
-  ./examples/basic-exp-sat.smt2))
+  ./examples/basic-exp-sat.smt2
+  ./examples/basic-bitvector-bitwise.smt2))

--- a/tests/smtlib.t
+++ b/tests/smtlib.t
@@ -23,3 +23,9 @@ Test bad
 
   $ Smtlib ./examples/bad-exp.smt2
   error during script evaluation: '=' expected all arguments to be formulas or terms; if you meant term the problem is 'only base two is supported'; if you meant formulas the problem is 'unimplemented SMT-lib construction: (Smtlib.SpecConstant (Smtlib.Numeric 9))'
+
+Test basic bitvectors
+
+  $ Smtlib ./examples/basic-bitvector-bitwise.smt2
+  sat
+  s = 0b11 (3) t = 0b10011 (19) 


### PR DESCRIPTION
This patch introduces simple bitvector arithmetic allowing to express
more complex regular constraints using bitwise operations.

The first patch adds bitwise operations and enables occasionally
disabled optimizations.

The second patch is less minor and introduces let syntax to smtlib.
