### PR TITLE
solver: apply optimizations in Semenov arithmetic

### DIFF
--- a/examples/fcp-exp-7-11.smt2
+++ b/examples/fcp-exp-7-11.smt2
@@ -1,0 +1,11 @@
+(set-info :smt-lib-version 2.6)
+(set-logic ALL)
+(set-info :status sat)
+
+(declare-fun P () Int)
+(declare-fun x () Int)
+; P = 59 (answer to Frobenius coin problem with 7 11), 2^x - 5 = 59, x = 8
+(assert (= (+ 5 P) (exp 2 x)))
+(assert (and (<= 0 P) (forall ((x0 Int) (x1 Int)) (=> (and (<= 0 x0) (<= 0 x1)) (not (= (+ (* x0 7) (* x1 11)) P)))) (forall ((R Int)) (=> (forall ((x0 Int) (x1 Int)) (=> (and (<= 0 x0) (<= 0 x1)) (not (= (+ (* x0 7) (* x1 11)) R)))) (<= R P)))))
+(check-sat)
+(exit)

--- a/lib/optimizer.ml
+++ b/lib/optimizer.ml
@@ -58,6 +58,7 @@ let apply_demourgan_law formula =
              | Ast.Mor (f1, f2) -> Ast.mand (Ast.mnot f1) (Ast.mnot f2)
              | Ast.Mand (f1, f2) -> Ast.mor (Ast.mnot f1) (Ast.mnot f2)
              | _ -> f)
+          | Ast.Mimpl (f, f') -> Ast.mor (Ast.mnot f) f'
           | _ as f -> f)
         Fun.id
         f

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -742,7 +742,10 @@ let proof f =
       f
   in
   if run_semenov
-  then proof_semenov f
+  then (
+    let f = Optimizer.optimize f in
+    Debug.printfln "optimized formula: %a" Ast.pp_formula f;
+    proof_semenov f)
   else (
     let f = Optimizer.optimize f in
     Debug.printfln "optimized formula: %a" Ast.pp_formula f;


### PR DESCRIPTION
This patch makes Semenov solving procedure use the optimizations and introduces a simplification of implication as disjunction of negation and the original expression.