### PR TITLE
[ci] Reenable docker build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -54,10 +54,10 @@ jobs:
         run: opam list
 
       - name: Build
-        run: opam exec -- dune build src bin tests
+        run: opam exec -- dune build lib bin tests
 
       - name: Tests
-        run: opam exec -- dune b @tests/runtest
+        run: opam exec -- dune b @lib/runtest @tests/runtest
 
       - name: Format
         run: opam exec -- dune fmt


### PR DESCRIPTION
From now on we build only our tests, not smtml ones. And we no longer install dependecies for smtml's tests.