### PR TITLE
solver: fix string solver when no RE constraints

### DIFF
--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -108,6 +108,9 @@ let collect_free (ir : Ir.t) =
     ir
 ;;
 
+let base = 10
+let alphabet = "0123456789ABCDEF" |> String.to_seq |> Seq.take base |> Array.of_seq
+
 let collect_alpha (ir : Ir.t) =
   let ( let* ) = Option.bind in
   let return = Option.some in
@@ -125,7 +128,7 @@ let collect_alpha (ir : Ir.t) =
       ir
   in
   let alpha = Set.diff alpha (Set.of_list [ Nfa.Str.u_eos; Nfa.Str.u_null ]) in
-  return (if Set.is_empty alpha then Set.singleton '0' else alpha)
+  return (if Set.is_empty alpha then Set.of_array alphabet else alpha)
 ;;
 
 let ir_atom_to_eia_term : Ir.atom -> Ast.Eia.term = function


### PR DESCRIPTION
This patch is a hotfix of a bug that occured at the moment if there were no string constraints within the input. The solver collected the symbols from the constant strings and build the corresponding automata only for them. That allowed to draw less edges in some specific NFAs like the ones for str.len. Unfortunately, it broke some of the benchmarks since an alphaben of only 0 had been used as a fallback if there were no string constraints within the example. That broke previously mentioned str.len and likely other benchmarks.

This patch makes the solver use digits `0--base - 1` as a fallback alphabet.

For instance, check the following trivial sat benchmark.

```
(set-logic QF_S)

(declare-const x String)
(declare-const y Int)
(declare-const z Int)

(assert (>= (str.to.int x) 10))
(assert (>= (str.to.int y) 10))
(assert (>= (str.to.int z) 10))

(assert (= (str.++ x y) z))

(check-sat)
```