### PR TITLE
etc: fix formatter version

### DIFF
--- a/Chrobelias.opam
+++ b/Chrobelias.opam
@@ -28,7 +28,7 @@ depends: [
   "ppx_inline_test"
   "mdx"
   "mdx" {with-tests}
-  "ocamlformat" {dev}
+  "ocamlformat" {dev & = "0.27.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,6 @@
   ppx_inline_test
   mdx
   (mdx :with-tests)
-  (ocamlformat :dev))
+  (ocamlformat (and :dev (= 0.27.0))))
  (tags
   (solver theorem)))


### PR DESCRIPTION
This patch fixes formatter version to 0.27.0 not to deal with different versions problems and formatting differences.