### PR TITLE
regex: take associativity into account

### DIFF
--- a/lib/nfa.ml
+++ b/lib/nfa.ml
@@ -1602,18 +1602,26 @@ struct
 
   let of_regex (r : Label.u list Regex.t) =
     let rec traverse visited = function
-      | [] -> []
-      | r :: tl ->
-        if List.exists (fun r' -> r' = r) visited
+      | s when Set.is_empty s -> []
+      | s ->
+        let r = Set.nth s 0 |> Option.get in
+        let tl = Set.remove_index s 0 in
+        if Set.mem visited r
         then traverse visited tl
         else (
-          let visited = r :: visited in
+          let visited = Set.add visited r in
           let symbols = Regex.symbols r in
           let delta = List.map (fun symbol -> symbol, Regex.deriv symbol r) symbols in
-          let tl = List.append (List.map snd delta) tl in
+          let tl =
+            Set.union
+              (List.map snd delta
+               |> List.filter (fun r' -> not (Set.mem visited r'))
+               |> Set.of_list)
+              tl
+          in
           (r, delta) :: traverse visited tl)
     in
-    let transitions = traverse [] [ r ] in
+    let transitions = traverse Set.empty (Set.singleton r) in
     let regex_to_state =
       transitions |> List.map fst |> List.mapi (fun i r -> r, i) |> Map.of_alist_exn
     in

--- a/lib/regex.ml
+++ b/lib/regex.ml
@@ -28,31 +28,33 @@ let rec pp pp_sym ppf = function
 
 let all = mnot empty
 
-let kleene = function
+let rec kleene = function
   | Kleene r -> kleene r
   | Epsilon -> Epsilon
   | Empty -> Epsilon
-  | r -> kleene r
+  | r -> Kleene r
 ;;
 
-let concat r' s' =
+let rec concat r' s' =
   match r', s' with
   | Empty, _ | _, Empty -> Empty
   | Epsilon, r | r, Epsilon -> r
-  | r, s -> concat r s
+  | Concat (r, s), t -> concat r (concat s t)
+  | r, s -> Concat (r, s)
 ;;
 
-let mor r' s' =
+let rec mor r' s' =
   match r', s' with
   | Empty, r | r, Empty -> r
   | Mor (r, s), t when t = s || t = r -> mor r s
   | t, Mor (r, s) when t = s || t = r -> mor r s
   | Mnot Empty, _ | _, Mnot Empty -> all
+  | Mor (r, s), t -> mor r (mor s t)
   | r, s when r = s -> r
-  | r, s -> mor r s
+  | r, s -> Mor (r, s)
 ;;
 
-let mand r' s' =
+let rec mand r' s' =
   match r', s' with
   | Empty, _ | _, Empty -> Empty
   | Epsilon, _ | _, Epsilon -> Epsilon
@@ -60,12 +62,12 @@ let mand r' s' =
   | Mand (r, s), t when t = s || t = r -> mand r s
   | t, Mand (r, s) when t = s || t = r -> mand r s
   | r, s when r = s -> r
-  | r, s -> mand r s
+  | r, s -> Mand (r, s)
 ;;
 
 let mnot = function
   | Mnot (Mnot r) -> r
-  | r -> mnot r
+  | r -> Mnot r
 ;;
 
 let plus r = concat r (kleene r)

--- a/tests/overapprox/1.t
+++ b/tests/overapprox/1.t
@@ -22,7 +22,7 @@ $ export CHRO_DEBUG=1
   $ export CHRO_TRACE_OPT=1
   $ Chro -bound 0 -no-over --dsimpl --stop-after simpl testO2.smt2 | sed 's/[[:space:]]*$//'
   (assert (= (+ (* (- 1) %0) x1 )  0) )
-  (assert ((re.* (re.union (re.union (re.union (str.to.re "1") (str.to.re "2")) (str.to.re "0")) (str.to.re "7")))))
+  (assert ((re.* (re.union (str.to.re "1") (re.union (str.to.re "2") (re.union (str.to.re "0") (str.to.re "7")))))))
   
 
 $ cat > test.smt2 <<-EOF

--- a/tests/regular/simple.t
+++ b/tests/regular/simple.t
@@ -11,22 +11,22 @@
   sat (presimpl str)
   iter(1)= (and
              (= a "-1099")
-             (str.in_re a (re.++ (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (str.to.re "-")) (re.* (str.to.re "")))))
+             (str.in_re a (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (re.++ (str.to.re "-") (re.* (str.to.re ""))))))
   Something ready to substitute
         a -> "-1099";
   
-  iter(2)= (str.in_re a (re.++ (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (str.to.re "-")) (re.* (str.to.re ""))))
+  iter(2)= (str.in_re a (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (re.++ (str.to.re "-") (re.* (str.to.re "")))))
   iter(3)= True
   fixed-point
   
   sat (presimpl str)
   iter(1)= (and
              (= a "-1090")
-             (str.in_re a (re.++ (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (str.to.re "-")) (re.* (str.to.re "")))))
+             (str.in_re a (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (re.++ (str.to.re "-") (re.* (str.to.re ""))))))
   Something ready to substitute
         a -> "-1090";
   
-  iter(2)= (str.in_re a (re.++ (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (str.to.re "-")) (re.* (str.to.re ""))))
+  iter(2)= (str.in_re a (re.++ (re.* (re.union (re.++ (str.to.re "0") (str.to.re "1")) (re.++ (str.to.re "9") (str.to.re "9")))) (re.++ (str.to.re "-") (re.* (str.to.re "")))))
   iter(3)= (not True)
   fixed-point
   

--- a/tests/strings/regex.t
+++ b/tests/strings/regex.t
@@ -1,0 +1,10 @@
+
+  $ cat > test1.smt2 <<-EOF
+  > (set-logic QF_SLIA)
+  > (declare-const x String) 
+  > (assert (str.in_re x (re.* (re.++ (str.to_re "a") (re.+ (str.to_re "aa"))))))
+  > (check-sat)
+  > EOF
+  $ Chro test1.smt2
+  sat (under int)
+


### PR DESCRIPTION
This patch makes all associative regex operations associate to the right
by default. This means that the following regex

```smt2
(re.++ (re.++ a b) (re.++ c d))
```

will be converted into:

```smt2
(re.++ a (re.++ b (re.++ c d)))
```
