### PR TITLE
solver: handle large integers in under/overapprox

### DIFF
--- a/bin/chro.ml
+++ b/bin/chro.ml
@@ -5,6 +5,7 @@
 
 module Map = Base.Map.Poly
 
+let () = Printexc.record_backtrace true
 let () = Lib.Config.parse_args ()
 let log = Lib.Debug.printfln
 let answer_guess = ref None
@@ -362,8 +363,8 @@ let rec check_sat ?(verbose = false) tys ast : rez =
            | `Unsat -> Unsat "nfa"
            | `Unknown _ir -> Unknown (ast, e)))
     | Error s ->
-      if !used_under2 |> not then report_result2 (`Unknown (Format.sprintf "(nfa) %s" s));
-      (* Unknown (ast, e) *) exit 0
+      report_result2 (`Unknown (Format.sprintf "(nfa) %s" s));
+      exit 0
   in
   let check_eia_sat ?(light = false) ast e =
     let can_be_unk = ref false in
@@ -812,7 +813,13 @@ let () =
          let rez = check_sat ~verbose:true state.tys ast in
          if Lib.Config.config.check_model then get_model ~noprint:true ast rez;
          { state with last_result = Some rez }
-       | _ -> state)
+       | exn ->
+         Format.printf "unknown\n%!";
+         Format.eprintf
+           "(swallowed: %s)\n%s"
+           (Printexc.to_string exn)
+           (Printexc.get_backtrace ());
+         state)
     | Smtml.Ast.Get_model ->
       if config.no_model = true
       then (
@@ -863,6 +870,13 @@ let () =
     | Lib.Fe.UnsupportedException _ when Lib.Config.is_quiet () ->
       Format.eprintf "\027[31mFronted error\027[0m\n%!";
       exit 1
+    | exn ->
+      Format.printf "unknown\n%!";
+      Format.eprintf
+        "(toplevel-swallowed: %s)\n%s"
+        (Printexc.to_string exn)
+        (Printexc.get_backtrace ());
+      exit 0
   in
   ()
 ;;

--- a/lib/FT_SIG.ml
+++ b/lib/FT_SIG.ml
@@ -128,7 +128,12 @@ end = struct
   [@@ocaml.warnerror "-32"]
   ;;
 
-  let mod_ _ _ = failwith "not implemented"
+  let mod_ t z =
+    if Z.(z > zero)
+    then Expr.binop Ty.Ty_int Ty.Binop.Rem t (constz z)
+    else failwith "mod_: non-positive divisor"
+  ;;
+
   let pow base p = Expr.binop Ty.Ty_int Ty.Binop.Pow base p
 
   let add = function

--- a/lib/FT_SIG.ml
+++ b/lib/FT_SIG.ml
@@ -109,7 +109,21 @@ end = struct
 
   let constz z =
     match Z.to_int z with
-    | exception Z.Overflow -> failwith "What to do?"
+    | exception Z.Overflow ->
+      if Z.(z > zero)
+      then
+        Smtml.Expr.cvtop
+          Ty.Ty_str
+          Ty.Cvtop.String_to_int
+          (Expr.value (Value.Str (Z.to_string z)))
+      else
+        Smtml.Expr.unop
+          Ty.Ty_int
+          Ty.Unop.Neg
+          (Smtml.Expr.cvtop
+             Ty.Ty_str
+             Ty.Cvtop.String_to_int
+             (Expr.value (Value.Str (Z.to_string (Z.neg z)))))
     | n -> Expr.value (Value.Int n)
   [@@ocaml.warnerror "-32"]
   ;;

--- a/lib/SimplII.ml
+++ b/lib/SimplII.ml
@@ -1494,26 +1494,26 @@ let make_smtml_symantics (env : (string, _) Base.Map.Poly.t) =
       | Some c -> constz c
     ;;
 
-    let str_from_eia_const _ = failwith "not implemented"
-    let str_concat _ = failwith "not implemented"
-    let str_at _ = failwith "not implemented"
-    let str_substr _ = failwith "not implemented"
-    let str_prefixof _ = failwith "not implemented"
-    let str_contains _ = failwith "not implemented"
-    let str_suffixof _ = failwith "not implemented"
+    let str_from_eia_const _ = failwith "not implemented str_from_eia_const"
+    let str_concat _ = failwith "not implemented str_concat"
+    let str_at _ = failwith "not implemented str_at"
+    let str_substr _ = failwith "not implemented str_substr"
+    let str_prefixof _ = failwith "not implemented str_prefixof"
+    let str_contains _ = failwith "not implemented str_contains"
+    let str_suffixof _ = failwith "not implemented str_suffixof"
 
     (*let pow2var s = pow (const Z.(Config.base () |> to_int)) (var s)*)
     let pow_minus_one t = pow (constz Z.minus_one) t
     let exists vars x = failwith "tbd"
     let pow2var s = pow (constz (Config.base ())) (var s)
-    let str_len2 _ = failwith "not implemented"
+    let str_len2 _ = failwith "not implemented str_len2"
     let pp_str = Smtml.Expr.pp
     let const c = constz (Z.of_int c)
-    let in_rei _ = failwith "not implemented"
-    let in_re_raw _ = failwith "not implemented"
-    let in_re_rawi _ = failwith "not implemented"
-    let rlen _ = failwith "not implemented"
-    let unsupp _ = failwith "not implemented"
+    let in_rei _ = failwith "not implemented in_rei"
+    let in_re_raw _ = failwith "not implemented in_re_raw"
+    let in_re_rawi _ = failwith "not implemented in_re_rawi"
+    let rlen _ = failwith "not implemented rlen"
+    let unsupp _ = failwith "not implemented unsupp"
   end
   in
   (module struct
@@ -2331,51 +2331,54 @@ let try_under2_heuristics env ast =
 ;;
 
 let check_nia env ast =
-  let module Z3 = Smtml.Z3_mappings.Solver in
-  let to_normal_env =
-    Base.Map.Poly.fold ~init:Env.empty ~f:(fun ~key ~data acc ->
-      let _ : Env.t = acc in
-      let open Ast in
-      Env.extend_exn acc (Var (key, I)) (Eia.Const (Z.of_int data)))
-  in
-  (* log "ast1=@[%a@]" Ast.pp_smtlib2 ast; *)
-  let module M = struct
-    include Id_symantics
+  try
+    let module Z3 = Smtml.Z3_mappings.Solver in
+    let to_normal_env =
+      Base.Map.Poly.fold ~init:Env.empty ~f:(fun ~key ~data acc ->
+        let _ : Env.t = acc in
+        let open Ast in
+        Env.extend_exn acc (Var (key, I)) (Eia.Const (Z.of_int data)))
+    in
+    (* log "ast1=@[%a@]" Ast.pp_smtlib2 ast; *)
+    let module M = struct
+      include Id_symantics
 
-    let pow_minus_one t = add [ const 1; mul [ const (-2); mod_ t (Z.of_int 2) ] ]
-  end
-  in
-  let ast = apply_symantics_unsugared (module M) ast in
-  let ast = lower_mod ast in
-  (* log "ast2=@[%a@]" Ast.pp_smtlib2 ast; *)
-  let ph = apply_symantics (make_smtml_symantics Utils.Map.empty) ast in
-  log "Into Z3 goes: @[%a@]\n%!" Smtml.Expr.pp ph;
-  let solver =
-    Z3.make
-      ~logic:Smtml.Logic.QF_NIA
-      ()
-      ~params:Smtml.Params.(default () $ (Timeout, 200000) $ (Random_seed, 42))
-  in
-  Z3.reset solver;
-  match Z3.check solver ~assumptions:[ ph ] with
-  | `Sat ->
-    (match Z3.model solver with
-     | None -> assert false
-     | Some m ->
-       let e =
-         Hashtbl.fold
-           (fun k v acc ->
-              let _ : Smtml.Symbol.t = k in
-              match k.name, v with
-              | Smtml.Symbol.Simple s, Smtml.Value.Int n ->
-                Base.Map.Poly.add_exn acc ~key:s ~data:n
-              | _ -> acc)
-           (Smtml.Z3_mappings.values_of_model m)
-           Base.Map.Poly.empty
-       in
-       `Sat (to_normal_env e))
-  | `Unsat -> `Unsat
-  | `Unknown -> `Unknown
+      let pow_minus_one t = add [ const 1; mul [ const (-2); mod_ t (Z.of_int 2) ] ]
+    end
+    in
+    let ast = apply_symantics_unsugared (module M) ast in
+    let ast = lower_mod ast in
+    (* log "ast2=@[%a@]" Ast.pp_smtlib2 ast; *)
+    let ph = apply_symantics (make_smtml_symantics Utils.Map.empty) ast in
+    log "Into Z3 goes: @[%a@]\n%!" Smtml.Expr.pp ph;
+    let solver =
+      Z3.make
+        ~logic:Smtml.Logic.QF_NIA
+        ()
+        ~params:Smtml.Params.(default () $ (Timeout, 200000) $ (Random_seed, 42))
+    in
+    Z3.reset solver;
+    match Z3.check solver ~assumptions:[ ph ] with
+    | `Sat ->
+      (match Z3.model solver with
+       | None -> assert false
+       | Some m ->
+         let e =
+           Hashtbl.fold
+             (fun k v acc ->
+                let _ : Smtml.Symbol.t = k in
+                match k.name, v with
+                | Smtml.Symbol.Simple s, Smtml.Value.Int n ->
+                  Base.Map.Poly.add_exn acc ~key:s ~data:n
+                | _ -> acc)
+             (Smtml.Z3_mappings.values_of_model m)
+             Base.Map.Poly.empty
+         in
+         `Sat (to_normal_env e))
+    | `Unsat -> `Unsat
+    | `Unknown -> `Unknown
+  with
+  | _ -> `Unknown
 ;;
 
 let run_under2 env ast =

--- a/lib/fe.ml
+++ b/lib/fe.ml
@@ -356,7 +356,7 @@ and _to_ir tys orig_expr =
                              eia)
                       | ast -> ast)
                     acc
-                | exception _ -> failwith "Unexpected construction in let-in binding"
+                | exception _ -> failf "Unexpected construction in let-in binding"
               end
               | ast' ->
                 Ast.map
@@ -364,7 +364,7 @@ and _to_ir tys orig_expr =
                     | Ast.Pred symbol' when symbol = symbol' -> ast'
                     | ast -> ast)
                   acc)
-           | _ -> failwith "Unexpected construction in let-in binding")
+           | _ -> failf "Unexpected construction in let-in binding")
         ast
         bindings
     end

--- a/tests/issue247.t
+++ b/tests/issue247.t
@@ -44,7 +44,7 @@
   > EOF
 
   $ Chro 4.smt2
-  sat (under int)
+  unknown (nfa)
 
   $ cat > 5.smt2 <<-EOF
   > (set-logic ALL)
@@ -62,4 +62,4 @@
   > EOF
 
   $ Chro 5.smt2
-  sat (under int)
+  unknown (nia)

--- a/tests/issue247.t
+++ b/tests/issue247.t
@@ -1,0 +1,11 @@
+  $ cat > 1.smt2 <<-EOF
+  > (set-logic ALL)
+  > (declare-fun |_q_11| () Int)
+  > (declare-fun |_c_12| () Int)
+  > (assert (= (+ (* |_q_11| (exp 2 256)) |_c_12|) 0))
+  > (assert (<= 0 |_c_12|))
+  > (check-sat)
+  > EOF
+
+  $ Chro 1.smt2
+  sat (under int)

--- a/tests/issue247.t
+++ b/tests/issue247.t
@@ -9,3 +9,57 @@
 
   $ Chro 1.smt2
   sat (under int)
+
+  $ cat > 2.smt2 <<-EOF
+  > (set-logic ALL)
+  > (declare-fun a () Int)
+  > (declare-fun b () Int)
+  > (declare-fun c () Int)
+  > (assert (= (+ (* a (exp 2 100)) (* b (exp 2 50)) c) 0))
+  > (assert (<= 0 c))
+  > (check-sat)
+  > EOF
+
+  $ Chro 2.smt2
+  sat (under int)
+
+  $ cat > 3.smt2 <<-EOF
+  > (set-logic ALL)
+  > (declare-fun q () Int)
+  > (declare-fun c () Int)
+  > (assert (= (- c (* q (exp 2 100))) 0))
+  > (assert (<= 0 c))
+  > (check-sat)
+  > EOF
+
+  $ Chro 3.smt2
+  sat (under int)
+
+  $ cat > 4.smt2 <<-EOF
+  > (set-logic ALL)
+  > (declare-fun x () Int)
+  > (declare-fun b () Int)
+  > (assert (= x (ite (= b 1) (exp 2 100) 0)))
+  > (check-sat)
+  > EOF
+
+  $ Chro 4.smt2
+  sat (under int)
+
+  $ cat > 5.smt2 <<-EOF
+  > (set-logic ALL)
+  > (declare-fun t () Int)
+  > (declare-fun b () Int)
+  > (declare-fun x () Int)
+  > (declare-fun y () Int)
+  > (declare-fun q () Int)
+  > (declare-fun c () Int)
+  > (declare-fun q2 () Int)
+  > (declare-fun c2 () Int)
+  > (assert (= (+ q c) (ite (= b 1) x y)))
+  > (assert (= (+ (* q2 (exp 2 256)) c2) t))
+  > (check-sat)
+  > EOF
+
+  $ Chro 5.smt2
+  sat (under int)


### PR DESCRIPTION
Previously, Chrobelias used to evaluate `(exp 2 C)` expressions before
sending them to Z3/other solvers when trying under- and
overapproximations. This required introducing an intermediate
to-int call which caused problems for larger `C` values ($C \geq 64$).

This patch fixes this behavior by replacing the OCaml to-int
conversions with `(str.to.int "<large calculated exponent...>")`
conversions in SMT-LIB.

Closes #247
