### PR TITLE
solver: enable nielsen & improve underapprox

### DIFF
--- a/bin/chro.ml
+++ b/bin/chro.ml
@@ -1307,7 +1307,20 @@ let () =
        Z3 contexts are not safe to share, so forking is what makes the two runs
        independent without auditing every one of them. *)
     let strategies =
-      [ ("under", fun () -> config.under_str_all <- true); ("normal", fun () -> ()) ]
+      [ ("under", fun () -> config.under_str_all <- true)
+      ; ("normal", fun () -> ())
+        (* Nielsen splitting is qualitatively stronger on word-equation
+           suites -- it cracks RElnc timeouts that more time alone never
+           does -- but ~10x slower on equations whose variables are pinned
+           by str.to_int, so it races as its own strategy rather than
+           being the default. Combined with the string underapproximation
+           because that pairing dominates: on the RElnc timeout set it
+           solves 40/42 (8 uniquely) where plain nielsen gets 34. *)
+      ; ( "nielsen"
+        , fun () ->
+            config.nielsen <- true;
+            config.under_str_all <- true )
+      ]
     in
     let children =
       List.map

--- a/bin/chro.ml
+++ b/bin/chro.ml
@@ -1306,8 +1306,17 @@ let () =
        mutable state -- fresh-name counters, the exponent cache, [smt_status] -- and
        Z3 contexts are not safe to share, so forking is what makes the two runs
        independent without auditing every one of them. *)
+    (* The under-approximation children get a larger enumeration budget:
+       spending seconds on candidate substitution is their whole purpose, and
+       the racing normal child keeps unsat latency unaffected. Deep product
+       witnesses (the stringfuzz [("0s", "0")] pairs) sit a few seconds into
+       the now honestly-chunked rounds. Explicit -budget still wins. *)
+    let deep_under () =
+      config.under_str_all <- true;
+      if Float.equal config.under_str_budget 1.0 then config.under_str_budget <- 4.0
+    in
     let strategies =
-      [ ("under", fun () -> config.under_str_all <- true)
+      [ "under", deep_under
       ; ("normal", fun () -> ())
         (* Nielsen splitting is qualitatively stronger on word-equation
            suites -- it cracks RElnc timeouts that more time alone never
@@ -1319,7 +1328,7 @@ let () =
       ; ( "nielsen"
         , fun () ->
             config.nielsen <- true;
-            config.under_str_all <- true )
+            deep_under () )
       ]
     in
     let children =

--- a/lib/Config.ml
+++ b/lib/Config.ml
@@ -17,6 +17,7 @@ type config =
        is what the solver did before the automaton existed -- the point of the
        switch is to be able to compare the two. *)
   ; mutable mod_eq : bool
+  ; mutable nielsen : bool
   ; mutable no_model : bool
   ; mutable no_str_bv : bool
   ; mutable over_approx : bool
@@ -59,6 +60,7 @@ let config =
   ; logic = `Eia
   ; mode = `Msb
   ; mod_eq = true
+  ; nielsen = false
   ; no_model = false
   ; no_str_bv = false
   ; quiet = false
@@ -187,6 +189,9 @@ Basic options:
       , Arg.Unit (fun () -> config.mod_eq <- false)
       , "\tDisable the congruence automaton: lower every 'mod' to a quotient and a \
          remainder" )
+    ; ( "-nielsen"
+      , Arg.Unit (fun () -> config.nielsen <- true)
+      , "\tEnable Nielsen transformations for word equations in the simplifier" )
     ; ( "-no-model"
       , Arg.Unit (fun () -> config.no_model <- true)
       , "\tDisable model generation subroutines" )

--- a/lib/Config.ml
+++ b/lib/Config.ml
@@ -92,6 +92,12 @@ type under2_config =
 type under_str_config =
   { mutable max_len : int
   ; mutable max_cnt : int
+    (* Total environments (candidate-string tuples) allowed per enumeration
+       round. The per-variable candidate count is [max_envs ** (1/m)] for [m]
+       variables, so a single unconstrained variable gets thousands of
+       candidates while three variables get a handful each -- balanced
+       against the size of the product instead of a flat per-variable cap. *)
+  ; mutable max_envs : int
   }
 
 type huge_const_config =
@@ -112,7 +118,7 @@ let huge_const () = huge_const_config.const
 let huge_path () = huge_const_config.path
 let huge_const_for_model () = huge_const_config.const_model
 let under2_config = { amin = 5; amax = 11; flat = -1 }
-let under_str_config = { max_len = 32; max_cnt = 32 }
+let under_str_config = { max_len = 32; max_cnt = 32; max_envs = 8192 }
 let get_flat () = under2_config.flat
 let is_under2_enabled () = get_flat () >= 0
 let bounded_unsat = ref false
@@ -212,6 +218,10 @@ Basic options:
       , Arg.Int (fun n -> under_str_config.max_len <- n)
       , "<n>\tUnderapproximate strings in concats via words of length at most <n> \
          (DEFAULT n=32)" )
+    ; ( "-sbenvs"
+      , Arg.Int (fun n -> under_str_config.max_envs <- n)
+      , "<n>\tCap on candidate environments per string underapproximation round (DEFAULT \
+         n=8192)" )
       (*; ( "-over"
       , Arg.Unit (fun () -> config.over_approx <- true)
       , "\tSimple overapprox" )*)

--- a/lib/SimplII.ml
+++ b/lib/SimplII.ml
@@ -3181,12 +3181,15 @@ let under_str env alpha vars ast =
       if String.length c > 0
       then String.sub c 0 (String.length c - 1)
       else c (* Format.printf ">>>>> %s\n%!" c; *))
-    |> List.fast_sort (fun x y ->
+    |> List.sort_uniq (fun x y ->
       match String.length x - String.length y with
       | 0 -> String.compare x y
       | diff -> diff)
     |> fun x ->
-    if length <= 0 && NfaS.re_accepts (String.to_seq "" |> List.of_seq) nfa
+    if
+      length <= 0
+      && NfaS.re_accepts (String.to_seq "" |> List.of_seq) nfa
+      && not (List.mem "" x)
     then "" :: x
     else x
   in
@@ -3205,7 +3208,35 @@ let under_str env alpha vars ast =
                 data)
             (collect_regexes ast)
         in
+        (* Balance the enumeration against the size of the product it feeds:
+           [max_envs] bounds the number of candidate tuples per round, so the
+           per-variable count is its [m]-th root -- a single unconstrained
+           variable gets thousands of candidates where three variables get a
+           handful each, instead of a flat [max_cnt] for every arity. *)
+        let per_var =
+          let cap = Config.under_str_config.max_envs in
+          let m = Set.length vars in
+          if cap < 0
+          then Config.under_str_config.max_cnt
+          else Int.max 2 (Float.to_int (Float.of_int cap ** (1. /. Float.of_int m)))
+        in
+        (* [base^l], clamped against overflow. *)
+        let space base l =
+          if l <= 0
+          then 1
+          else if Float.of_int l *. Float.log2 (Float.of_int base) >= 30.
+          then Int.max_int
+          else Utils.pow ~base l
+        in
+        let numeric = Ast.get_stoi_vars ast |> Set.of_list in
         let all_as name =
+          let known_len = Ast.get_len name ast in
+          (* The full alphabet for every variable, digits included. Narrowing
+             a [str.to_int]-read variable to digits looks tempting, but its
+             [to_int v = -1] branches are witnessed only by strings with a
+             non-digit character -- e.g. the stringfuzz instances whose model
+             is [m = "0s"] -- so the narrowing silently loses real models.
+             Only the candidate counts are balanced, never the alphabet. *)
           let alpha =
             alpha
             |> Set.of_list
@@ -3217,23 +3248,56 @@ let under_str env alpha vars ast =
             |> Set.to_list
           in
           let nfa_alpha = Regex.all alpha |> NfaS.of_regex in
-          let max_cnt = Config.under_str_config.max_cnt in
-          let length = Ast.get_len name ast in
-          let length, exact, count =
-            match length >= 0, Map.mem regexes name with
-            | true, other ->
-              length, true, min max_cnt (Utils.pow ~base:(List.length alpha) length)
-            | false, true -> length, false, max_cnt
-            | _ -> len, false, max_cnt
+          let is_regex = Ast.is_conjunct ast && Map.mem regexes name in
+          (* A regex-constrained variable gets its ranged enumeration in the
+             very first round: its witnesses are as long as the regex pumps,
+             so waiting for their exact-length round would push them past the
+             caller's time budget. Later rounds still add exact-length
+             coverage beyond the initial sample. *)
+          (* Regex-constrained variables keep the small flat cap: their
+             candidates are pumped words whose length grows with the index,
+             and every extra candidate makes both the substitution and the
+             automata check on the residual superlinearly more expensive --
+             the balanced root budget only makes sense for the flat-cost
+             alphabet enumeration. *)
+          let per_var =
+            if is_regex then min per_var Config.under_str_config.max_cnt else per_var
+          in
+          let length, count =
+            if known_len >= 0
+            then known_len, min per_var (space (List.length alpha) known_len)
+            else if is_regex && len = 0
+            then -1, per_var
+            else len, min per_var (space (List.length alpha) len)
           in
           let list =
             get_strings_range
-              (if Ast.is_conjunct ast && Map.mem regexes name
-               then Map.find_exn regexes name
-               else nfa_alpha)
+              (if is_regex then Map.find_exn regexes name else nfa_alpha)
               length
-              ~exact
+              ~exact:true
               count
+          in
+          (* A variable read as a number gets a digit-only sample *prepended*:
+             most of its useful witnesses are digit-dense, but the full
+             alphabet stays in the pool -- ordering is the safe form of the
+             digit bias, exclusion loses the [to_int v = -1] witnesses (the
+             stringfuzz models like [m = "0s"]). *)
+          let list =
+            let is_digits s = String.for_all (fun c -> '0' <= c && c <= '9') s in
+            if is_regex || (not (Set.mem numeric name)) || length < 0
+            then list
+            else (
+              let digit_nfa =
+                Regex.all (Regex.dec |> String.to_seq |> List.of_seq) |> NfaS.of_regex
+              in
+              let digits =
+                get_strings_range
+                  digit_nfa
+                  length
+                  ~exact:true
+                  (min count (space 10 length))
+              in
+              digits @ List.filter (fun s -> not (is_digits s)) list)
           in
           trace_log
             "Strings for %s:\n %a\n%!"
@@ -3251,13 +3315,7 @@ let under_str env alpha vars ast =
           ~init:[ env ]
           vars
       in
-      List.map
-        (fun e ->
-           let (module Symantics) = make_main_symantics e in
-           (* trace_log "AST: %a\n%!" Ast.pp_smtlib2 ast;
-         trace_log "@[%a@]" (Env.pp ~title:"env = ") e; *)
-           e, apply_symantics (module Symantics) ast)
-        envs)
+      envs)
   in
   if Config.under_str_config.max_cnt < 0
   then Seq.empty
@@ -3273,12 +3331,34 @@ let under_str env alpha vars ast =
         | `Sat env -> raise_notrace (Str_Underapprox_fired env)
         | `Unknown (ast, env, _, _) -> Some (ast (*|> over_concat_len*), env))
     in
+    (* A round can hold thousands of candidate environments, but the caller's
+       time budget is only checked between the variants of this sequence, so
+       each round is emitted as [max_cnt]-sized chunks -- substitution
+       included, lazily per chunk -- to keep that deadline meaningful. A fat
+       round would otherwise run to completion long past it. *)
+    let chunk_size = Int.max 1 Config.under_str_config.max_cnt in
+    let rec chunks lst =
+      match lst with
+      | [] -> []
+      | _ ->
+        let hd, tl = Base.List.split_n lst chunk_size in
+        hd :: chunks tl
+    in
     let m = List.length vars in
     Seq.init (m * (Config.under_str_config.max_len + 1)) (fun x -> x / m, x mod m)
-    |> Seq.map (fun (length, side) ->
+    |> Seq.concat_map (fun (length, side) ->
       match side with
       | n when n >= 0 && n < m ->
-        filter_asts (try_under_str (List.nth vars n) alpha length env ast)
+        try_under_str (List.nth vars n) alpha length env ast
+        |> chunks
+        |> List.to_seq
+        |> Seq.map (fun chunk ->
+          filter_asts
+            (List.map
+               (fun e ->
+                  let (module Symantics) = make_main_symantics e in
+                  e, apply_symantics (module Symantics) ast)
+               chunk))
       | other -> failwith "Unreachable: remainder is negative"))
 ;;
 

--- a/lib/SimplII.ml
+++ b/lib/SimplII.ml
@@ -3406,7 +3406,7 @@ let extract_and_filter_unsupported_atomic_formulas ast =
 
 let run_string_simplify ast =
   (let module Set = Set in
-   match basic_simplify [ 1 ] ~with_nielsen:false Env.empty ast with
+   match basic_simplify [ 1 ] ~with_nielsen:Config.config.nielsen Env.empty ast with
    | `Sat env -> `Sat env
    | `Unsat unsat_core -> `Unsat unsat_core
    | `Unknown (ast', e, _, _) ->

--- a/lib/SimplII.ml
+++ b/lib/SimplII.ml
@@ -3168,6 +3168,38 @@ let run_length_simplify env ast =
 
 let under_str env alpha vars ast =
   let module Map = Base.Map.Poly in
+  (* A variable is *provably numeric* when replacing its direct
+     [str.to_int v] reading with -1 collapses the formula to
+     unsatisfiable: every model then has [to_int v >= 0], i.e. [v] is a
+     non-empty digit string, and enumerating its candidates over the
+     decimal alphabet alone loses nothing. This is the sound form of
+     the digit bias -- HashFunction's [mod (to_int x) m = c] proves it,
+     while a formula that is satisfiable through [to_int v = -1] (the
+     stringfuzz models like [m = "0s"]) keeps the full alphabet. *)
+  let proven_digit =
+    Ast.get_stoi_vars ast
+    |> List.filter (fun v ->
+      let ast' =
+        Ast.map
+          (function
+            | Ast.Eia eia ->
+              Ast.eia
+                (Ast.Eia.map2
+                   Fun.id
+                   (function
+                     | Ast.Eia.Iofs (Ast.Eia.Atom (Ast.Var (u, Ast.S)))
+                       when String.equal u v -> Ast.Eia.Const Z.minus_one
+                     | t -> t)
+                   Fun.id
+                   eia)
+            | ph -> ph)
+          ast
+      in
+      match basic_simplify [] ~minimize:false env ast' with
+      | `Unsat _ -> true
+      | `Sat _ | `Unknown _ -> false)
+    |> Set.of_list
+  in
   let get_strings_range nfa length ?(exact = false) num =
     let max_len = Config.under_str_config.max_len in
     (if length < 0
@@ -3228,24 +3260,20 @@ let under_str env alpha vars ast =
           then Int.max_int
           else Utils.pow ~base l
         in
-        let numeric = Ast.get_stoi_vars ast |> Set.of_list in
         let all_as name =
           let known_len = Ast.get_len name ast in
-          (* The full alphabet for every variable, digits included. Narrowing
-             a [str.to_int]-read variable to digits looks tempting, but its
-             [to_int v = -1] branches are witnessed only by strings with a
-             non-digit character -- e.g. the stringfuzz instances whose model
-             is [m = "0s"] -- so the narrowing silently loses real models.
-             Only the candidate counts are balanced, never the alphabet. *)
           let alpha =
-            alpha
-            |> Set.of_list
-            |> (fun x ->
-            Seq.fold_left
-              (fun acc digit -> Set.add acc digit)
-              x
-              (Regex.dec |> String.to_seq))
-            |> Set.to_list
+            if Set.mem proven_digit name
+            then Regex.dec |> String.to_seq |> List.of_seq
+            else
+              alpha
+              |> Set.of_list
+              |> (fun x ->
+              Seq.fold_left
+                (fun acc digit -> Set.add acc digit)
+                x
+                (Regex.dec |> String.to_seq))
+              |> Set.to_list
           in
           let nfa_alpha = Regex.all alpha |> NfaS.of_regex in
           let is_regex = Ast.is_conjunct ast && Map.mem regexes name in
@@ -3263,41 +3291,36 @@ let under_str env alpha vars ast =
           let per_var =
             if is_regex then min per_var Config.under_str_config.max_cnt else per_var
           in
-          let length, count =
-            if known_len >= 0
-            then known_len, min per_var (space (List.length alpha) known_len)
+          (* Multi-variable sets keep the legacy sampler: ranged rounds with
+             the flat cap. The balanced exact-length enumeration below is
+             only proven for singletons; for products it reshuffles which
+             slice of the tuple space gets sampled and loses low-total-length
+             witness pairs (the stringfuzz [("0s", "0")] models) that the
+             legacy breadth-first order happens to reach. Products get the
+             principled treatment when enumeration by total length across
+             the set lands. *)
+          let legacy = Set.length vars >= 2 in
+          let length, exact, count =
+            if legacy
+            then (
+              let max_cnt = Config.under_str_config.max_cnt in
+              if known_len >= 0
+              then known_len, true, min max_cnt (space (List.length alpha) known_len)
+              else if is_regex
+              then -1, false, max_cnt
+              else len, false, max_cnt)
+            else if known_len >= 0
+            then known_len, true, min per_var (space (List.length alpha) known_len)
             else if is_regex && len = 0
-            then -1, per_var
-            else len, min per_var (space (List.length alpha) len)
+            then -1, true, per_var
+            else len, true, min per_var (space (List.length alpha) len)
           in
           let list =
             get_strings_range
               (if is_regex then Map.find_exn regexes name else nfa_alpha)
               length
-              ~exact:true
+              ~exact
               count
-          in
-          (* A variable read as a number gets a digit-only sample *prepended*:
-             most of its useful witnesses are digit-dense, but the full
-             alphabet stays in the pool -- ordering is the safe form of the
-             digit bias, exclusion loses the [to_int v = -1] witnesses (the
-             stringfuzz models like [m = "0s"]). *)
-          let list =
-            let is_digits s = String.for_all (fun c -> '0' <= c && c <= '9') s in
-            if is_regex || (not (Set.mem numeric name)) || length < 0
-            then list
-            else (
-              let digit_nfa =
-                Regex.all (Regex.dec |> String.to_seq |> List.of_seq) |> NfaS.of_regex
-              in
-              let digits =
-                get_strings_range
-                  digit_nfa
-                  length
-                  ~exact:true
-                  (min count (space 10 length))
-              in
-              digits @ List.filter (fun s -> not (is_digits s)) list)
           in
           trace_log
             "Strings for %s:\n %a\n%!"
@@ -3349,7 +3372,8 @@ let under_str env alpha vars ast =
     |> Seq.concat_map (fun (length, side) ->
       match side with
       | n when n >= 0 && n < m ->
-        try_under_str (List.nth vars n) alpha length env ast
+        let set = List.nth vars n in
+        try_under_str set alpha length env ast
         |> chunks
         |> List.to_seq
         |> Seq.map (fun chunk ->


### PR DESCRIPTION
- **solver: add -nielsen switch for word-equation transformations**
- **solver: race a nielsen strategy in the portfolio**
- **simpl: balance the string underapproximation enumeration**
- **simpl: infer provably-numeric variables for the underapproximation**
